### PR TITLE
#17: Abhängigkeiten zwischen Elementen

### DIFF
--- a/classes/deserializable.php
+++ b/classes/deserializable.php
@@ -14,54 +14,22 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\form\elements;
-
-use qtype_questionpy\form\render_context;
+namespace qtype_questionpy;
 
 /**
- * Element grouping one or more checkboxes with a `Select all/none` button.
+ * Interface for classes which can be deserialized from an array.
  *
  * @package    qtype_questionpy
  * @author     Maximilian Haye
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class checkbox_group_element extends form_element {
-    /** @var checkbox_element[] */
-    public array $checkboxes = [];
-
-    /**
-     * Initializes the element.
-     *
-     * @param checkbox_element ...$checkboxes
-     */
-    public function __construct(checkbox_element...$checkboxes) {
-        $this->checkboxes = $checkboxes;
-    }
-
-    /**
-     * Render this item to the given context.
-     *
-     * @param render_context $context target context
-     * @package qtype_questionpy
-     */
-    public function render_to(render_context $context): void {
-        $groupid = $context->next_unique_int();
-
-        foreach ($this->checkboxes as $checkbox) {
-            $checkbox->render_to($context, $groupid);
-        }
-
-        $context->add_checkbox_controller($groupid);
-    }
-
+interface deserializable {
     /**
      * Convert the given array to the concrete element without checking the `kind` descriptor.
      * (Which is done by {@see from_array_any}.)
      *
      * @param array $array source array, probably parsed from JSON
      */
-    public static function from_array(array $array): self {
-        return new self(...array_map([checkbox_element::class, "from_array"], $array["checkboxes"]));
-    }
+    public static function from_array(array $array): self;
 }

--- a/classes/form/conditions/condition.php
+++ b/classes/form/conditions/condition.php
@@ -14,21 +14,41 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\form\elements;
+namespace qtype_questionpy\form\conditions;
 
 use qtype_questionpy\deserializable;
-use qtype_questionpy\form\renderable;
 use qtype_questionpy\kind_deserialize;
 
 /**
- * Base class for QuestionPy form elements.
+ * Base class for QuestionPy form element conditions.
  *
  * @package    qtype_questionpy
  * @author     Maximilian Haye
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-abstract class form_element implements renderable, \JsonSerializable, deserializable {
+abstract class condition implements deserializable, \JsonSerializable {
+
+    /** @var string $name name of the target element */
+    public string $name;
+
+    /**
+     * Initializes the condition.
+     *
+     * @param string $name name of the target element
+     */
+    public function __construct(string $name) {
+        $this->name = $name;
+    }
+
+    /**
+     * Return the `[$condition]` or `[$condition, $value]` tuple  to pass to {@see \MoodleQuickForm::disabledIf()} or
+     * {@see \MoodleQuickForm::hideIf()} after the depended on element's name.
+     *
+     * @return array
+     */
+    abstract public function to_mform_args(): array;
+
     use kind_deserialize;
 
     /**
@@ -38,16 +58,13 @@ abstract class form_element implements renderable, \JsonSerializable, deserializ
      * it to determine the concrete class to use for deserialization. This method should be implemented by the base
      * class of the hierarchy.
      */
-    final protected static function kinds(): array {
+    protected static function kinds(): array {
         return [
-            "checkbox" => checkbox_element::class,
-            "checkbox_group" => checkbox_group_element::class,
-            "group" => group_element::class,
-            "hidden" => hidden_element::class,
-            "radio_group" => radio_group_element::class,
-            "select" => select_element::class,
-            "static_text" => static_text_element::class,
-            "text_input" => text_input_element::class,
+            "is_checked" => is_checked::class,
+            "is_not_checked" => is_not_checked::class,
+            "equals" => equals::class,
+            "does_not_equal" => does_not_equal::class,
+            "in" => in::class,
         ];
     }
 }

--- a/classes/form/conditions/condition_with_value.php
+++ b/classes/form/conditions/condition_with_value.php
@@ -1,0 +1,42 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\form\conditions;
+
+/**
+ * Base class for conditions which compare the target element with some value..
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+abstract class condition_with_value extends condition {
+
+    /** @var mixed value which the target element value will be compared with */
+    public $value;
+
+    /**
+     * Initializes the condition.
+     *
+     * @param string $name name of the target element
+     * @param mixed $value value which the target element value will be compared with
+     */
+    public function __construct(string $name, $value) {
+        parent::__construct($name);
+        $this->value = $value;
+    }
+}

--- a/classes/form/conditions/does_not_equal.php
+++ b/classes/form/conditions/does_not_equal.php
@@ -14,54 +14,37 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\form\elements;
-
-use qtype_questionpy\form\render_context;
+namespace qtype_questionpy\form\conditions;
 
 /**
- * Element grouping one or more checkboxes with a `Select all/none` button.
+ * Condition checking whether the target form element value is not equal to the given value.
  *
  * @package    qtype_questionpy
  * @author     Maximilian Haye
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class checkbox_group_element extends form_element {
-    /** @var checkbox_element[] */
-    public array $checkboxes = [];
+class does_not_equal extends condition_with_value {
 
     /**
-     * Initializes the element.
+     * Return the `[$condition]` or `[$condition, $value]` tuple  to pass to {@see \MoodleQuickForm::disabledIf()} or
+     * {@see \MoodleQuickForm::hideIf()} after the depended on element's name.
      *
-     * @param checkbox_element ...$checkboxes
+     * @return array
      */
-    public function __construct(checkbox_element...$checkboxes) {
-        $this->checkboxes = $checkboxes;
+    public function to_mform_args(): array {
+        return ["neq", $this->value];
     }
 
     /**
-     * Render this item to the given context.
-     *
-     * @param render_context $context target context
-     * @package qtype_questionpy
-     */
-    public function render_to(render_context $context): void {
-        $groupid = $context->next_unique_int();
-
-        foreach ($this->checkboxes as $checkbox) {
-            $checkbox->render_to($context, $groupid);
-        }
-
-        $context->add_checkbox_controller($groupid);
-    }
-
-    /**
-     * Convert the given array to the concrete element without checking the `kind` descriptor.
+     * Convert the given array to the concrete instance without checking the `kind` descriptor.
      * (Which is done by {@see from_array_any}.)
+     *
+     * This method should be implemented by the concrete implementations.
      *
      * @param array $array source array, probably parsed from JSON
      */
     public static function from_array(array $array): self {
-        return new self(...array_map([checkbox_element::class, "from_array"], $array["checkboxes"]));
+        return new self($array["name"], $array["value"]);
     }
 }

--- a/classes/form/conditions/equals.php
+++ b/classes/form/conditions/equals.php
@@ -14,54 +14,37 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\form\elements;
-
-use qtype_questionpy\form\render_context;
+namespace qtype_questionpy\form\conditions;
 
 /**
- * Element grouping one or more checkboxes with a `Select all/none` button.
+ * Condition checking whether the target form element value is equal to the given value.
  *
  * @package    qtype_questionpy
  * @author     Maximilian Haye
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class checkbox_group_element extends form_element {
-    /** @var checkbox_element[] */
-    public array $checkboxes = [];
+class equals extends condition_with_value {
 
     /**
-     * Initializes the element.
+     * Return the `[$condition]` or `[$condition, $value]` tuple  to pass to {@see \MoodleQuickForm::disabledIf()} or
+     * {@see \MoodleQuickForm::hideIf()} after the depended on element's name.
      *
-     * @param checkbox_element ...$checkboxes
+     * @return array
      */
-    public function __construct(checkbox_element...$checkboxes) {
-        $this->checkboxes = $checkboxes;
+    public function to_mform_args(): array {
+        return ["eq", $this->value];
     }
 
     /**
-     * Render this item to the given context.
-     *
-     * @param render_context $context target context
-     * @package qtype_questionpy
-     */
-    public function render_to(render_context $context): void {
-        $groupid = $context->next_unique_int();
-
-        foreach ($this->checkboxes as $checkbox) {
-            $checkbox->render_to($context, $groupid);
-        }
-
-        $context->add_checkbox_controller($groupid);
-    }
-
-    /**
-     * Convert the given array to the concrete element without checking the `kind` descriptor.
+     * Convert the given array to the concrete instance without checking the `kind` descriptor.
      * (Which is done by {@see from_array_any}.)
+     *
+     * This method should be implemented by the concrete implementations.
      *
      * @param array $array source array, probably parsed from JSON
      */
     public static function from_array(array $array): self {
-        return new self(...array_map([checkbox_element::class, "from_array"], $array["checkboxes"]));
+        return new self($array["name"], $array["value"]);
     }
 }

--- a/classes/form/conditions/in.php
+++ b/classes/form/conditions/in.php
@@ -14,54 +14,37 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\form\elements;
-
-use qtype_questionpy\form\render_context;
+namespace qtype_questionpy\form\conditions;
 
 /**
- * Element grouping one or more checkboxes with a `Select all/none` button.
+ * Condition checking whether the target form element value is contained in a list of given possible values.
  *
  * @package    qtype_questionpy
  * @author     Maximilian Haye
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class checkbox_group_element extends form_element {
-    /** @var checkbox_element[] */
-    public array $checkboxes = [];
+class in extends condition_with_value {
 
     /**
-     * Initializes the element.
+     * Return the `[$condition]` or `[$condition, $value]` tuple  to pass to {@see \MoodleQuickForm::disabledIf()} or
+     * {@see \MoodleQuickForm::hideIf()} after the depended on element's name.
      *
-     * @param checkbox_element ...$checkboxes
+     * @return array
      */
-    public function __construct(checkbox_element...$checkboxes) {
-        $this->checkboxes = $checkboxes;
+    public function to_mform_args(): array {
+        return ["in", $this->value];
     }
 
     /**
-     * Render this item to the given context.
-     *
-     * @param render_context $context target context
-     * @package qtype_questionpy
-     */
-    public function render_to(render_context $context): void {
-        $groupid = $context->next_unique_int();
-
-        foreach ($this->checkboxes as $checkbox) {
-            $checkbox->render_to($context, $groupid);
-        }
-
-        $context->add_checkbox_controller($groupid);
-    }
-
-    /**
-     * Convert the given array to the concrete element without checking the `kind` descriptor.
+     * Convert the given array to the concrete instance without checking the `kind` descriptor.
      * (Which is done by {@see from_array_any}.)
+     *
+     * This method should be implemented by the concrete implementations.
      *
      * @param array $array source array, probably parsed from JSON
      */
     public static function from_array(array $array): self {
-        return new self(...array_map([checkbox_element::class, "from_array"], $array["checkboxes"]));
+        return new self($array["name"], $array["value"]);
     }
 }

--- a/classes/form/conditions/is_checked.php
+++ b/classes/form/conditions/is_checked.php
@@ -14,54 +14,37 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\form\elements;
-
-use qtype_questionpy\form\render_context;
+namespace qtype_questionpy\form\conditions;
 
 /**
- * Element grouping one or more checkboxes with a `Select all/none` button.
+ * Condition checking whether the target form element is a checked checkbox.
  *
  * @package    qtype_questionpy
  * @author     Maximilian Haye
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class checkbox_group_element extends form_element {
-    /** @var checkbox_element[] */
-    public array $checkboxes = [];
+class is_checked extends condition {
 
     /**
-     * Initializes the element.
+     * Return the `[$condition]` or `[$condition, $value]` tuple  to pass to {@see \MoodleQuickForm::disabledIf()} or
+     * {@see \MoodleQuickForm::hideIf()} after the depended on element's name.
      *
-     * @param checkbox_element ...$checkboxes
+     * @return array
      */
-    public function __construct(checkbox_element...$checkboxes) {
-        $this->checkboxes = $checkboxes;
+    public function to_mform_args(): array {
+        return ["checked"];
     }
 
     /**
-     * Render this item to the given context.
-     *
-     * @param render_context $context target context
-     * @package qtype_questionpy
-     */
-    public function render_to(render_context $context): void {
-        $groupid = $context->next_unique_int();
-
-        foreach ($this->checkboxes as $checkbox) {
-            $checkbox->render_to($context, $groupid);
-        }
-
-        $context->add_checkbox_controller($groupid);
-    }
-
-    /**
-     * Convert the given array to the concrete element without checking the `kind` descriptor.
+     * Convert the given array to the concrete instance without checking the `kind` descriptor.
      * (Which is done by {@see from_array_any}.)
+     *
+     * This method should be implemented by the concrete implementations.
      *
      * @param array $array source array, probably parsed from JSON
      */
     public static function from_array(array $array): self {
-        return new self(...array_map([checkbox_element::class, "from_array"], $array["checkboxes"]));
+        return new self($array["name"]);
     }
 }

--- a/classes/form/conditions/is_not_checked.php
+++ b/classes/form/conditions/is_not_checked.php
@@ -14,54 +14,37 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\form\elements;
-
-use qtype_questionpy\form\render_context;
+namespace qtype_questionpy\form\conditions;
 
 /**
- * Element grouping one or more checkboxes with a `Select all/none` button.
+ * Condition checking whether the target form element value is an unchecked checkbox.
  *
  * @package    qtype_questionpy
  * @author     Maximilian Haye
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class checkbox_group_element extends form_element {
-    /** @var checkbox_element[] */
-    public array $checkboxes = [];
+class is_not_checked extends condition {
 
     /**
-     * Initializes the element.
+     * Return the `[$condition]` or `[$condition, $value]` tuple  to pass to {@see \MoodleQuickForm::disabledIf()} or
+     * {@see \MoodleQuickForm::hideIf()} after the depended on element's name.
      *
-     * @param checkbox_element ...$checkboxes
+     * @return array
      */
-    public function __construct(checkbox_element...$checkboxes) {
-        $this->checkboxes = $checkboxes;
+    public function to_mform_args(): array {
+        return ["notchecked"];
     }
 
     /**
-     * Render this item to the given context.
-     *
-     * @param render_context $context target context
-     * @package qtype_questionpy
-     */
-    public function render_to(render_context $context): void {
-        $groupid = $context->next_unique_int();
-
-        foreach ($this->checkboxes as $checkbox) {
-            $checkbox->render_to($context, $groupid);
-        }
-
-        $context->add_checkbox_controller($groupid);
-    }
-
-    /**
-     * Convert the given array to the concrete element without checking the `kind` descriptor.
+     * Convert the given array to the concrete instance without checking the `kind` descriptor.
      * (Which is done by {@see from_array_any}.)
+     *
+     * This method should be implemented by the concrete implementations.
      *
      * @param array $array source array, probably parsed from JSON
      */
     public static function from_array(array $array): self {
-        return new self(...array_map([checkbox_element::class, "from_array"], $array["checkboxes"]));
+        return new self($array["name"]);
     }
 }

--- a/classes/form/elements/checkbox_element.php
+++ b/classes/form/elements/checkbox_element.php
@@ -16,6 +16,7 @@
 
 namespace qtype_questionpy\form\elements;
 
+use qtype_questionpy\form\form_conditions;
 use qtype_questionpy\form\render_context;
 
 /**
@@ -37,6 +38,8 @@ class checkbox_element extends form_element {
     public bool $required = false;
     /** @var bool */
     public bool $selected = false;
+
+    use form_conditions;
 
     /**
      * Initializes the element.
@@ -63,13 +66,13 @@ class checkbox_element extends form_element {
      * @param array $array source array, probably parsed from JSON
      */
     public static function from_array(array $array): self {
-        return new self(
+        return (new self(
             $array["name"],
             $array["left_label"] ?? null,
             $array["right_label"] ?? null,
             $array["required"] ?? false,
             $array["selected"] ?? false,
-        );
+        ))->deserialize_conditions($array);
     }
 
     /**
@@ -78,23 +81,13 @@ class checkbox_element extends form_element {
      * class property names.
      */
     public function to_array(): array {
-        return [
+        return $this->serialize_conditions([
             "name" => $this->name,
             "left_label" => $this->leftlabel,
             "right_label" => $this->rightlabel,
             "required" => $this->required,
             "selected" => $this->selected,
-        ];
-    }
-
-    /**
-     * The `kind` field of an element's JSON representation serves as a descriptor field. {@see from_array_any()} uses
-     * it to determine the concrete class to use for deserialization.
-     *
-     * @return string the value of this element's `kind` field.
-     */
-    protected static function kind(): string {
-        return "checkbox";
+        ]);
     }
 
     /**
@@ -116,5 +109,7 @@ class checkbox_element extends form_element {
         if ($this->required) {
             $context->add_rule($this->name, get_string("required"), "required");
         }
+
+        $this->render_conditions($context, $this->name);
     }
 }

--- a/classes/form/elements/hidden_element.php
+++ b/classes/form/elements/hidden_element.php
@@ -16,6 +16,7 @@
 
 namespace qtype_questionpy\form\elements;
 
+use qtype_questionpy\form\form_conditions;
 use qtype_questionpy\form\render_context;
 
 /**
@@ -32,6 +33,8 @@ class hidden_element extends form_element {
     /** @var string */
     public string $value;
 
+    use form_conditions;
+
     /**
      * Initializes the element.
      *
@@ -44,26 +47,26 @@ class hidden_element extends form_element {
     }
 
     /**
-     * The `kind` field of an element's JSON representation serves as a descriptor field. {@see from_array_any()} uses
-     * it to determine the concrete class to use for deserialization.
-     *
-     * @return string the value of this element's `kind` field.
-     */
-    protected static function kind(): string {
-        return "hidden";
-    }
-
-    /**
      * Convert the given array to the concrete element without checking the `kind` descriptor.
      * (Which is done by {@see from_array_any}.)
      *
      * @param array $array source array, probably parsed from JSON
      */
     public static function from_array(array $array): self {
-        return new self(
+        return (new self(
             $array["name"],
             $array["value"]
-        );
+        ))->deserialize_conditions($array);
+    }
+
+    /**
+     * Convert this element except for the `kind` descriptor to an array suitable for json encoding.
+     *
+     * The default implementation just casts to an array, which is suitable only if the json field names match the
+     * class property names.
+     */
+    public function to_array(): array {
+        return $this->serialize_conditions(parent::to_array());
     }
 
     /**
@@ -75,5 +78,7 @@ class hidden_element extends form_element {
     public function render_to(render_context $context): void {
         $context->add_element("hidden", $this->name, $this->value);
         $context->set_type($this->name, PARAM_TEXT);
+
+        $this->render_conditions($context, $this->name);
     }
 }

--- a/classes/form/elements/option.php
+++ b/classes/form/elements/option.php
@@ -16,6 +16,8 @@
 
 namespace qtype_questionpy\form\elements;
 
+use qtype_questionpy\deserializable;
+
 /**
  * One option in a {@see radio_group_element} or a {@see select_element}.
  *
@@ -24,7 +26,7 @@ namespace qtype_questionpy\form\elements;
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class option {
+class option implements deserializable {
     /** @var string */
     public string $label;
     /** @var string */

--- a/classes/form/elements/select_element.php
+++ b/classes/form/elements/select_element.php
@@ -17,6 +17,7 @@
 namespace qtype_questionpy\form\elements;
 
 use HTML_QuickForm_select;
+use qtype_questionpy\form\form_conditions;
 use qtype_questionpy\form\render_context;
 
 /**
@@ -39,6 +40,8 @@ class select_element extends form_element {
     /** @var bool */
     public bool $required = false;
 
+    use form_conditions;
+
     /**
      * Initializes the element.
      *
@@ -58,29 +61,29 @@ class select_element extends form_element {
     }
 
     /**
-     * The `kind` field of an element's JSON representation serves as a descriptor field. {@see from_array_any()} uses
-     * it to determine the concrete class to use for deserialization.
-     *
-     * @return string the value of this element's `kind` field.
-     */
-    protected static function kind(): string {
-        return "select";
-    }
-
-    /**
      * Convert the given array to the concrete element without checking the `kind` descriptor.
      * (Which is done by {@see from_array_any}.)
      *
      * @param array $array source array, probably parsed from JSON
      */
     public static function from_array(array $array): self {
-        return new self(
+        return (new self(
             $array["name"],
             $array["label"],
             array_map([option::class, "from_array"], $array["options"]),
             $array["multiple"] ?? false,
             $array["required"] ?? false,
-        );
+        ))->deserialize_conditions($array);
+    }
+
+    /**
+     * Convert this element except for the `kind` descriptor to an array suitable for json encoding.
+     *
+     * The default implementation just casts to an array, which is suitable only if the json field names match the
+     * class property names.
+     */
+    public function to_array(): array {
+        return $this->serialize_conditions(parent::to_array());
     }
 
     /**
@@ -108,5 +111,7 @@ class select_element extends form_element {
         if ($this->required) {
             $context->add_rule($this->name, null, "required");
         }
+
+        $this->render_conditions($context, $this->name);
     }
 }

--- a/classes/form/elements/text_input_element.php
+++ b/classes/form/elements/text_input_element.php
@@ -16,6 +16,7 @@
 
 namespace qtype_questionpy\form\elements;
 
+use qtype_questionpy\form\form_conditions;
 use qtype_questionpy\form\render_context;
 
 /**
@@ -37,6 +38,8 @@ class text_input_element extends form_element {
     public ?string $default = null;
     /** @var string|null */
     public ?string $placeholder = null;
+
+    use form_conditions;
 
     /**
      * Initializes the element.
@@ -68,23 +71,23 @@ class text_input_element extends form_element {
      * @param array $array source array, probably parsed from JSON
      */
     public static function from_array(array $array): self {
-        return new self(
+        return (new self(
             $array["name"],
             $array["label"],
             $array["required"] ?? false,
             $array["default"] ?? null,
             $array["placeholder"] ?? null,
-        );
+        ))->deserialize_conditions($array);
     }
 
     /**
-     * The `kind` field of an element's JSON representation serves as a descriptor field. {@see from_array_any()} uses
-     * it to determine the concrete class to use for deserialization.
+     * Convert this element except for the `kind` descriptor to an array suitable for json encoding.
      *
-     * @return string the value of this element's `kind` field.
+     * The default implementation just casts to an array, which is suitable only if the json field names match the
+     * class property names.
      */
-    protected static function kind(): string {
-        return "text_input";
+    public function to_array(): array {
+        return $this->serialize_conditions(parent::to_array());
     }
 
     /**
@@ -104,5 +107,7 @@ class text_input_element extends form_element {
         if ($this->required) {
             $context->add_rule($this->name, null, "required");
         }
+
+        $this->render_conditions($context, $this->name);
     }
 }

--- a/classes/form/form_conditions.php
+++ b/classes/form/form_conditions.php
@@ -1,0 +1,99 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\form;
+
+use qtype_questionpy\deserializable;
+use qtype_questionpy\form\conditions\condition;
+use qtype_questionpy\form\elements\form_element;
+
+/**
+ * Trait for elements which can have conditions on other elements.
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+trait form_conditions {
+    /** @var condition[] */
+    public array $disableif = [];
+    /** @var condition[] */
+    public array $hideif = [];
+
+    /**
+     * Renders the conditions. To be called by the {@see renderable::render_to() render_to} of elements.
+     *
+     * @param render_context $context target context
+     * @param string $name            name of this element
+     */
+    private function render_conditions(render_context $context, string $name) {
+        foreach ($this->disableif as $disableif) {
+            $context->disable_if($name, $disableif);
+        }
+
+        foreach ($this->hideif as $hideif) {
+            $context->hide_if($name, $hideif);
+        }
+    }
+
+    /**
+     * Deserializes the conditions from an array, mutating this instance and returning it for chaining.
+     *
+     * @param array $array source array, probably parsed from JSON
+     * @see deserializable::from_array()
+     */
+    private function deserialize_conditions(array $array): self {
+        $this->disableif = array_map([condition::class, "from_array_any"], $array["disable_if"]) ?? [];
+        $this->hideif = array_map([condition::class, "from_array_any"], $array["hide_if"]) ?? [];
+        return $this;
+    }
+
+    /**
+     * Adds the conditions of this element to the given array and return it.
+     *
+     * @param array $array incomplete array representation of this element
+     * @see form_element::to_array()
+     */
+    private function serialize_conditions(array $array): array {
+        unset($array["disableif"], $array["hideif"]);
+        $array["disable_if"] = $this->disableif;
+        $array["hide_if"] = $this->hideif;
+        return $array;
+    }
+
+    /**
+     * Adds the given condition to {@see disableif} and returns this instance for chaining.
+     *
+     * @param condition $condition the condition to add
+     * @return self $this
+     */
+    public function disable_if(condition $condition): self {
+        $this->disableif[] = $condition;
+        return $this;
+    }
+
+    /**
+     * Adds the given condition to {@see hideif} and returns this instance for chaining.
+     *
+     * @param condition $condition the condition to add
+     * @return self $this
+     */
+    public function hide_if(condition $condition): self {
+        $this->hideif[] = $condition;
+        return $this;
+    }
+}

--- a/classes/form/form_section.php
+++ b/classes/form/form_section.php
@@ -16,6 +16,7 @@
 
 namespace qtype_questionpy\form;
 
+use qtype_questionpy\deserializable;
 use qtype_questionpy\form\elements\form_element;
 
 /**
@@ -26,7 +27,7 @@ use qtype_questionpy\form\elements\form_element;
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class form_section implements renderable {
+class form_section implements renderable, deserializable {
     /** @var string */
     public string $header;
     /** @var form_element[] */

--- a/classes/form/qpy_form.php
+++ b/classes/form/qpy_form.php
@@ -16,6 +16,7 @@
 
 namespace qtype_questionpy\form;
 
+use qtype_questionpy\deserializable;
 use qtype_questionpy\form\elements\form_element;
 
 /**
@@ -26,7 +27,7 @@ use qtype_questionpy\form\elements\form_element;
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class qpy_form implements renderable {
+class qpy_form implements renderable, deserializable {
     /** @var form_element[] elements to be appended to the default "General" section */
     public array $general;
     /** @var form_section[] additional custom sections */

--- a/classes/form/render_context.php
+++ b/classes/form/render_context.php
@@ -16,6 +16,8 @@
 
 namespace qtype_questionpy\form;
 
+use qtype_questionpy\form\conditions\condition;
+
 /**
  * Abstracts away the differences in rendering elements in a group and outside of a group.
  *
@@ -99,6 +101,24 @@ abstract class render_context {
      */
     abstract public function add_rule(string  $name, ?string $message, string $type, ?string $format = null,
                                       ?string $validation = "server", bool $reset = false, bool $force = false): void;
+
+    /**
+     * Adds a condition which will disable the named element if met.
+     *
+     * @param string $dependant name of the element which has the dependency on another element
+     * @param condition $condition
+     * @see \MoodleQuickForm::disabledIf()
+     */
+    abstract public function disable_if(string $dependant, condition $condition);
+
+    /**
+     * Adds a condition which will hide the named element if met.
+     *
+     * @param string $dependant name of the element which has the dependency on another element
+     * @param condition $condition
+     * @see \MoodleQuickForm::hideIf()
+     */
+    abstract public function hide_if(string $dependant, condition $condition);
 
     /**
      * Get a unique and deterministic integer for use in generated element names and IDs.

--- a/classes/form/root_render_context.php
+++ b/classes/form/root_render_context.php
@@ -16,6 +16,8 @@
 
 namespace qtype_questionpy\form;
 
+use qtype_questionpy\form\conditions\condition;
+
 /**
  * Regular {@see render_context} which delegates to {@see \moodleform} and {@see \MoodleQuickForm}.
  *
@@ -86,6 +88,28 @@ class root_render_context extends render_context {
     public function add_rule(string  $name, ?string $message, string $type, ?string $format = null,
                              ?string $validation = "server", bool $reset = false, bool $force = false): void {
         $this->mform->addRule($name, $message, $type, $format, $validation, $reset, $force);
+    }
+
+    /**
+     * Adds a condition which will disable the named element if met.
+     *
+     * @param string $dependant name of the element which has the dependency on another element
+     * @param condition $condition
+     * @see \MoodleQuickForm::disabledIf()
+     */
+    public function disable_if(string $dependant, condition $condition) {
+        $this->mform->disabledIf($dependant, $condition->name, ...$condition->to_mform_args());
+    }
+
+    /**
+     * Adds a condition which will hide the named element if met.
+     *
+     * @param string $dependant name of the element which has the dependency on another element
+     * @param condition $condition
+     * @see \MoodleQuickForm::hideIf()
+     */
+    public function hide_if(string $dependant, condition $condition) {
+        $this->mform->hideIf($dependant, $condition->name, ...$condition->to_mform_args());
     }
 
     /**

--- a/classes/kind_deserialize.php
+++ b/classes/kind_deserialize.php
@@ -1,0 +1,85 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy;
+
+/**
+ * Deserializes a hierarchy of classes using a discriminator field `kind`.
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+trait kind_deserialize {
+    /**
+     * Returns an array mapping each possible kind value to the associated concrete class name.
+     *
+     * The `kind` field of an element's JSON representation serves as a descriptor field. {@see from_array_any()} uses
+     * it to determine the concrete class to use for deserialization. This method should be implemented by the base
+     * class of the hierarchy.
+     */
+    abstract protected static function kinds(): array;
+
+    /**
+     * Convert the given array to the concrete instance without checking the `kind` descriptor.
+     * (Which is done by {@see from_array_any}.)
+     *
+     * This method should be implemented by the concrete implementations.
+     *
+     * @param array $array source array, probably parsed from JSON
+     */
+    abstract public static function from_array(array $array): self;
+
+    /**
+     * Convert this element except for the `kind` descriptor to an array suitable for json encoding.
+     *
+     * The default implementation just casts to an array, which is suitable only if the json field names match the
+     * class property names.
+     */
+    public function to_array(): array {
+        return (array)$this;
+    }
+
+    /**
+     * Use the value of the `kind` descriptor to convert the given array to the correct concrete element,
+     * delegating to the appropriate {@see from_array} implementation.
+     *
+     * @param array $array source array, probably parsed from JSON
+     */
+    final public static function from_array_any(array $array): self {
+        $kind = $array["kind"];
+        unset($array["kind"]);
+
+        $class = self::kinds()[$kind] ?? null;
+        if ($class === null) {
+            throw new \RuntimeException("Unknown kind: " . $kind);
+        }
+
+        return $class::from_array($array);
+    }
+
+    /**
+     * Serializes this element by calling {@see to_array} and adding its {@see kinds `kind`} to the result.
+     */
+    final public function jsonSerialize(): array {
+        $kind = array_flip(self::kinds())[get_class($this)];
+        return array_merge(
+            ["kind" => $kind],
+            $this->to_array()
+        );
+    }
+}

--- a/edit_questionpy_form.php
+++ b/edit_questionpy_form.php
@@ -23,7 +23,8 @@
  */
 
 use qtype_questionpy\api;
-use qtype_questionpy\localizer;
+use qtype_questionpy\form\conditions\equals;
+use qtype_questionpy\form\conditions\is_not_checked;
 use qtype_questionpy\form\elements\checkbox_element;
 use qtype_questionpy\form\elements\checkbox_group_element;
 use qtype_questionpy\form\elements\group_element;
@@ -35,6 +36,7 @@ use qtype_questionpy\form\elements\text_input_element;
 use qtype_questionpy\form\form_section;
 use qtype_questionpy\form\qpy_form;
 use qtype_questionpy\form\root_render_context;
+use qtype_questionpy\localizer;
 
 /**
  * QuestionPy question editing form definition.
@@ -58,17 +60,21 @@ class qtype_questionpy_edit_form extends question_edit_form {
 
         // No packages received.
         if (!$packages) {
-            $mform->addElement('static', 'questionpy_no_package',
+            $mform->addElement(
+                'static', 'questionpy_no_package',
                 get_string('selection_no_package_title', 'qtype_questionpy'),
-                get_string('selection_no_package_text', 'qtype_questionpy'));
+                get_string('selection_no_package_text', 'qtype_questionpy')
+            );
 
             return;
         }
 
         // Searchbar for QuestionPy packages.
-        $mform->addElement('text', 'questionpy_package_search',
+        $mform->addElement(
+            'text', 'questionpy_package_search',
             get_string('selection_title', 'qtype_questionpy'),
-            ['placeholder' => get_string('selection_searchbar', 'qtype_questionpy')]);
+            ['placeholder' => get_string('selection_searchbar', 'qtype_questionpy')]
+        );
 
         $mform->setType('questionpy_package_search', PARAM_TEXT);
 
@@ -96,11 +102,11 @@ class qtype_questionpy_edit_form extends question_edit_form {
         $mform->addElement('button', 'uploadlink', 'QPy Package upload form', $uploadlink);
 
         $form = new qpy_form([
-            new static_text_element("Some blurb", "This is just for lookin' at"),
+            new static_text_element("my_static_text", "Some blurb", "This is just for lookin' at"),
             new text_input_element("some_text", "Enter some text", true, "default", "placeholder"),
             new select_element("select1", "A dropdown", [
                 new option("Option 1", "opt1"),
-                new option("Option 2", "opt2", true),
+                new option("Option 2", "opt2"),
             ], true, true),
             new checkbox_group_element(
                 new checkbox_element("chk1", "Option 1", null, true, true),
@@ -114,14 +120,16 @@ class qtype_questionpy_edit_form extends question_edit_form {
                 new option("Option 1", "opt1"),
                 new option("Option 2", "opt2"),
             ], true),
-            new group_element("grp1", "A group", [
-                new text_input_element("first_name", "First", true),
-                new text_input_element("last_name", "Last"),
-            ]),
         ], [
-            new form_section("Custom Section", [
-                new text_input_element("more_text", "Enter some more text"),
-                new checkbox_element("chk5", "Left Label", "Right Label", true, true),
+            new form_section("Conditional Element Demo", [
+                new checkbox_element("show_all", null, "Check me to show some more elements"),
+                (new group_element("name_group", "Your Name", [
+                    new text_input_element("first_name", "First", true),
+                    new text_input_element("last_name", "Last"),
+                ]))->hide_if(new is_not_checked("show_all")),
+                (new checkbox_element("last_name_public", null, "Show my last name on my public profile"))
+                    ->hide_if(new is_not_checked("show_all"))
+                    ->disable_if(new equals("last_name", ""))
             ]),
         ]);
         $form->render_to(new root_render_context($this, $mform));

--- a/tests/form/elements/element_html_test.php
+++ b/tests/form/elements/element_html_test.php
@@ -98,7 +98,7 @@ class element_html_test extends \advanced_testcase {
                 new option("Option 1", "opt1", true),
                 new option("Option 2", "opt2"),
             ], true, true)],
-            ["static_text.html", new static_text_element("Label", "Lorem ipsum dolor sit amet.")],
+            ["static_text.html", new static_text_element("my_text", "Label", "Lorem ipsum dolor sit amet.")],
             ["text_input.html", new text_input_element("my_field", "Label", true, "default", "placeholder")],
         ];
     }

--- a/tests/form/elements/element_json_test.php
+++ b/tests/form/elements/element_json_test.php
@@ -16,6 +16,12 @@
 
 namespace qtype_questionpy\form\elements;
 
+use qtype_questionpy\form\conditions\does_not_equal;
+use qtype_questionpy\form\conditions\equals;
+use qtype_questionpy\form\conditions\in;
+use qtype_questionpy\form\conditions\is_checked;
+use qtype_questionpy\form\conditions\is_not_checked;
+
 /**
  * Tests of the (de)serialization of form elements.
  *
@@ -71,27 +77,29 @@ class element_json_test extends \advanced_testcase {
      */
     public function serialize_provider(): array {
         return [
-            ["checkbox.json", new checkbox_element("my_checkbox", "Left", "Right", true, true)],
+            ["checkbox.json", (new checkbox_element("my_checkbox", "Left", "Right", true, true))->disable_if(
+                new is_checked("chk1")
+            )],
             ["checkbox_group.json", new checkbox_group_element(
                 new checkbox_element(
                     "my_checkbox", "Left", "Right",
                     true, true
                 )
             )],
-            ["group.json", new group_element("my_group", "Name", [
+            ["group.json", (new group_element("my_group", "Name", [
                 new text_input_element("first_name", "", true, null, "Vorname"),
                 new text_input_element("last_name", "", false, null, "Nachname (optional)"),
-            ])],
-            ["hidden.json", new hidden_element("my_hidden_value", "42")],
-            ["radio_group.json", new radio_group_element("my_radio", "Label", [
+            ]))->hide_if(new is_not_checked("chk1"))],
+            ["hidden.json", (new hidden_element("my_hidden_value", "42"))->disable_if(new equals("input1", 7))],
+            ["radio_group.json", (new radio_group_element("my_radio", "Label", [
                 new option("Option 1", "opt1", true),
                 new option("Option 2", "opt2"),
-            ], true)],
-            ["select.json", new select_element("my_select", "Label", [
+            ], true))->disable_if(new does_not_equal("input1", ""))],
+            ["select.json", (new select_element("my_select", "Label", [
                 new option("Option 1", "opt1", true),
                 new option("Option 2", "opt2"),
-            ], true, true)],
-            ["static_text.json", new static_text_element("Label", "Lorem ipsum dolor sit amet.")],
+            ], true, true))->disable_if(new in("input1", ["valid", "also valid"])) ],
+            ["static_text.json", new static_text_element("my_text", "Label", "Lorem ipsum dolor sit amet.")],
             ["text_input.json", new text_input_element("my_field", "Label", true, "default", "placeholder")],
         ];
     }

--- a/tests/form/elements/html/static_text.html
+++ b/tests/form/elements/html/static_text.html
@@ -4,7 +4,7 @@
 <input name="_qf__qtype_questionpy_form_elements_test_moodleform" type="hidden" value="1">
 </div>
 
-<div id="fitem_id_qpy_static_text_1" class="form-group row  fitem   ">
+<div id="fitem_id_my_text" class="form-group row  fitem   ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
                 <span class="d-inline-block ">
@@ -19,7 +19,7 @@
         <div class="form-control-static">
         Lorem ipsum dolor sit amet.
         </div>
-        <div class="form-control-feedback invalid-feedback" id="id_error_qpy_static_text_1">
+        <div class="form-control-feedback invalid-feedback" id="id_error_my_text">
             
         </div>
     </div>

--- a/tests/form/elements/json/checkbox.json
+++ b/tests/form/elements/json/checkbox.json
@@ -4,5 +4,12 @@
   "left_label": "Left",
   "right_label": "Right",
   "required": true,
-  "selected": true
+  "selected": true,
+  "disable_if": [
+    {
+      "kind": "is_checked",
+      "name": "chk1"
+    }
+  ],
+  "hide_if": []
 }

--- a/tests/form/elements/json/checkbox_group.json
+++ b/tests/form/elements/json/checkbox_group.json
@@ -7,7 +7,9 @@
       "left_label": "Left",
       "right_label": "Right",
       "required": true,
-      "selected": true
+      "selected": true,
+      "disable_if": [],
+      "hide_if": []
     }
   ]
 }

--- a/tests/form/elements/json/group.json
+++ b/tests/form/elements/json/group.json
@@ -9,7 +9,9 @@
       "label": "",
       "required": true,
       "default": null,
-      "placeholder": "Vorname"
+      "placeholder": "Vorname",
+      "disable_if": [],
+      "hide_if": []
     },
     {
       "kind": "text_input",
@@ -17,7 +19,16 @@
       "label": "",
       "required": false,
       "default": null,
-      "placeholder": "Nachname (optional)"
+      "placeholder": "Nachname (optional)",
+      "disable_if": [],
+      "hide_if": []
+    }
+  ],
+  "disable_if": [],
+  "hide_if": [
+    {
+      "kind": "is_not_checked",
+      "name": "chk1"
     }
   ]
 }

--- a/tests/form/elements/json/hidden.json
+++ b/tests/form/elements/json/hidden.json
@@ -1,5 +1,13 @@
 {
   "kind": "hidden",
   "name": "my_hidden_value",
-  "value": "42"
+  "value": "42",
+  "disable_if": [
+    {
+      "kind": "equals",
+      "name": "input1",
+      "value": 7
+    }
+  ],
+  "hide_if": []
 }

--- a/tests/form/elements/json/radio_group.json
+++ b/tests/form/elements/json/radio_group.json
@@ -14,5 +14,13 @@
       "selected": false
     }
   ],
-  "required": true
+  "required": true,
+  "disable_if": [
+    {
+      "kind": "does_not_equal",
+      "name": "input1",
+      "value": ""
+    }
+  ],
+  "hide_if": []
 }

--- a/tests/form/elements/json/select.json
+++ b/tests/form/elements/json/select.json
@@ -15,5 +15,16 @@
     }
   ],
   "multiple": true,
-  "required": true
+  "required": true,
+  "disable_if": [
+    {
+      "kind": "in",
+      "name": "input1",
+      "value": [
+        "valid",
+        "also valid"
+      ]
+    }
+  ],
+  "hide_if": []
 }

--- a/tests/form/elements/json/static_text.json
+++ b/tests/form/elements/json/static_text.json
@@ -1,5 +1,8 @@
 {
   "kind": "static_text",
+  "name": "my_text",
   "label": "Label",
-  "text": "Lorem ipsum dolor sit amet."
+  "text": "Lorem ipsum dolor sit amet.",
+  "disable_if": [],
+  "hide_if": []
 }

--- a/tests/form/elements/json/text_input.json
+++ b/tests/form/elements/json/text_input.json
@@ -4,5 +4,7 @@
   "label": "Label",
   "default": "default",
   "placeholder": "placeholder",
-  "required": true
+  "required": true,
+  "disable_if": [],
+  "hide_if": []
 }


### PR DESCRIPTION
Implementiert pendants zu Moodle's `disabledIf` und `hideIf`. Dieser PR basiert auf #16, der zuerst gemergt werden sollte. Die CI failt aufgrund eines false positives, das mit moodlehq/moodle-local_moodlecheck#97 gefixt wird.

Die Conditions `is_checked`, `is_not_checked`, `equals`, `does_not_equal` und `in` habe ich implementiert. Moodle kennt noch eine weitere: `noitemselected`. Die scheint aber nicht zu funktionieren. Wenn wir die auch abbilden wollen, muss ich nochmal tiefer gucken, wo der Fehler liegt.

Closes #17 