### PR TITLE
Feature/19/package post

### DIFF
--- a/classes/api.php
+++ b/classes/api.php
@@ -114,19 +114,17 @@ class api {
      *
      * @param string $filename
      * @param string $filepath
-     * @param bool $withhash if true: calculates the package hash and sends it with the request
      * @return http_response_container
+     * @throws moodle_exception
      */
-    public static function post_package(string $filename, string $filepath, bool $withhash = false): http_response_container {
+    public static function package_extract_info(string $filename, string $filepath): http_response_container {
         $curlfile = curl_file_create($filepath, $filename);
         $data = [
             'package' => $curlfile
         ];
-        $path = "/packages/";
-        if ($withhash) {
-            $path = $path . hash_file('sha256', $filepath);
-        }
         $connector = self::create_connector();
-        return $connector->post($path, $data);
+        return $connector->post("/package-extract-info", $data);
     }
 }
+
+

--- a/classes/api.php
+++ b/classes/api.php
@@ -119,13 +119,12 @@ class api {
     public static function post_package(string $filename, string $filepath): http_response_container {
         $curlfile = curl_file_create($filepath, $filename);
         $data = [
-            "hash" => hash_file('sha256', $filepath),
-            "package" => $curlfile
+            'main' => 'main',
+            'hash' => hash_file('sha256', $filepath),
+            'package' => $curlfile
         ];
 
         $connector = self::create_connector();
-        $response = $connector->post("/package", $data);
-
-        return $response;
+        return $connector->post('/package', $data);
     }
 }

--- a/classes/api.php
+++ b/classes/api.php
@@ -109,4 +109,23 @@ class api {
         return $response->get_data(false);
     }
 
+    /**
+     * Post a .qpy QuestionPy package to the server.
+     *
+     * @param string $filename
+     * @param string $filepath
+     * @return http_response_container
+     */
+    public static function post_package(string $filename, string $filepath): http_response_container {
+        $curlfile = curl_file_create($filepath, $filename);
+        $data = [
+            "hash" => hash_file('sha256', $filepath),
+            "package" => $curlfile
+        ];
+
+        $connector = self::create_connector();
+        $response = $connector->post("/package", $data);
+
+        return $response;
+    }
 }

--- a/classes/api.php
+++ b/classes/api.php
@@ -110,21 +110,23 @@ class api {
     }
 
     /**
-     * Post a .qpy QuestionPy package to the server.
+     * Get the Package information from the server.
      *
      * @param string $filename
      * @param string $filepath
+     * @param bool $withhash if true: calculates the package hash and sends it with the request
      * @return http_response_container
      */
-    public static function post_package(string $filename, string $filepath): http_response_container {
+    public static function post_package(string $filename, string $filepath, bool $withhash = false): http_response_container {
         $curlfile = curl_file_create($filepath, $filename);
         $data = [
-            'main' => 'main',
-            'hash' => hash_file('sha256', $filepath),
             'package' => $curlfile
         ];
-
+        $path = "/packages/";
+        if ($withhash) {
+            $path = $path . hash_file('sha256', $filepath);
+        }
         $connector = self::create_connector();
-        return $connector->post('/package', $data);
+        return $connector->post($path, $data);
     }
 }

--- a/classes/form/package_upload.php
+++ b/classes/form/package_upload.php
@@ -65,7 +65,7 @@ class package_upload extends \moodleform {
             );
         }
         $mform->addGroup($group, 'questionpy_package_container', '', '</br>');
-        $mform->setType('questionpy_package_container', 'PARAM_RAW');
+        $mform->setType('questionpy_package_container', PARAM_TEXT);
 
         $maxbytes = get_config('qtype_questionpy', 'applicationserver_maxquestionsize');
         $mform->addElement('filepicker', 'qpy_package', get_string('file'), null,

--- a/classes/package.php
+++ b/classes/package.php
@@ -213,7 +213,6 @@ class package {
 
         $transaction = $DB->start_delegated_transaction();
         $packageid = $DB->insert_record('qtype_questionpy_package', $packagedata);
-        $transaction->allow_commit();
 
         // For each language store the localized package data as a separate record.
         $languagedata = array();
@@ -235,7 +234,6 @@ class package {
             ];
         }
 
-        $transaction = $DB->start_delegated_transaction();
         $DB->insert_records('qtype_questionpy_tags', $tagsdata);
         $DB->insert_records('qtype_questionpy_language', $languagedata);
         $transaction->allow_commit();

--- a/edit_questionpy_form.php
+++ b/edit_questionpy_form.php
@@ -46,6 +46,8 @@ class qtype_questionpy_edit_form extends question_edit_form {
         // Retrieve packages from the application server.
         $packages = api::get_packages();
 
+        $uploadlink = $PAGE->get_renderer('qtype_questionpy')->package_upload_link($this->context);
+
         // No packages received.
         if (!$packages) {
             $mform->addElement(
@@ -54,6 +56,7 @@ class qtype_questionpy_edit_form extends question_edit_form {
                 get_string('selection_no_package_text', 'qtype_questionpy')
             );
 
+            $mform->addElement('button', 'uploadlink', 'QPy Package upload form', $uploadlink);
             return;
         }
 
@@ -86,7 +89,6 @@ class qtype_questionpy_edit_form extends question_edit_form {
             'questionpy_package_container', get_string('selection_required', 'qtype_questionpy'), 'required'
         );
 
-        $uploadlink = $PAGE->get_renderer('qtype_questionpy')->package_upload_link($this->context);
         $mform->addElement('button', 'uploadlink', 'QPy Package upload form', $uploadlink);
 
         // While not a button, we need a way of telling moodle not to save the submitted data to the question when the

--- a/upload_view.php
+++ b/upload_view.php
@@ -94,11 +94,9 @@ if ($mform->is_cancelled()) {
                 $errormessage = $errormessage . $ex->getMessage();
             }
         }
-        // redirect($thisurl, $errormessage, 500, notification::NOTIFY_ERROR);
         notice($errormessage, $thisurl);
     }
     notice("Package saved.", $thisurl);
-    // redirect($thisurl, "Package saved.", 500, notification::NOTIFY_SUCCESS);
 } else {
     $mform->display();
 }

--- a/upload_view.php
+++ b/upload_view.php
@@ -23,19 +23,19 @@
  */
 
 use qtype_questionpy\package;
-use qtype_questionpy\localizer;
 use qtype_questionpy\api;
 
 require_once(dirname(__FILE__) . '/../../../config.php');
 
-$courseid = required_param('courseid', PARAM_INT);
+$courseid = optional_param('courseid', 2, PARAM_INT);
 
 require_login($courseid);
 $context = context_course::instance($courseid);
 
 require_capability('qtype/questionpy:uploadpackages', $context);
 $PAGE->set_context($context);
-$PAGE->set_url(new moodle_url('/question/type/questionpy/upload_view.php', ['courseid' => $courseid]));
+$thisurl = new moodle_url('/question/type/questionpy/upload_view.php', ['courseid' => $courseid]);
+$PAGE->set_url($thisurl);
 $PAGE->set_pagelayout('popup');
 $PAGE->set_title(get_string('pluginname', 'qtype_questionpy'));
 $output = $PAGE->get_renderer('core');
@@ -52,28 +52,30 @@ if ($mform->is_cancelled()) {
     // This redirect shows a warning, but should be ok (see: https://tracker.moodle.org/browse/CONTRIB-5857).
     redirect(new moodle_url('/course/view.php', ['id' => $courseid]), 'Upload form cancelled.');
 } else if ($fromform = $mform->get_data()) {
-    $thisurl = new moodle_url('/question/type/questionpy/upload_view.php', ['courseid' => $fromform->courseid]);
-
-    $name = $mform->get_new_filename('qpy_package');
-    if ($fs->file_exists($context->id, 'qtype_questionpy', 'package', 0, '/', $name)) {
-         redirect($thisurl, "File with this name already exists in this context.",
-             500, \core\output\notification::NOTIFY_WARNING);
+    // File has been submitted in the form. Check if a file with this name already exists in this context.
+    $filename = $mform->get_new_filename('qpy_package');
+    if ($fs->file_exists($context->id, 'qtype_questionpy', 'package', 0, '/', $filename)) {
+         redirect($thisurl, "File with this name already exists in this context.", 500, \core\output\notification::NOTIFY_WARNING);
     }
 
+    // Store file locally with the File API.
     $storedfile = $mform->save_stored_file('qpy_package', $context->id, 'qtype_questionpy',
-        'package', 0, '/', $name);
+        'package', 0, '/', $filename);
 
+    // Try to post the file to the server.
     $filesystem = $fs->get_file_system();
     $path = $filesystem->get_local_path_from_storedfile($storedfile, true);
-    $response = api::post_package($name, $path);
-    if ($response->code != http_response_code(200)) {
+    $response = api::post_package($filename, $path);
+
+    if ($response->code != http_response_code(201)) {
+        // If the file could not be saved on the server, also delete it in the file API.
         $storedfile->delete();
-        redirect($thisurl, "HTTP Response code: " . $response->code,
-          500, \core\output\notification::NOTIFY_ERROR);
-    } else {
-        $package = package::from_array($response->get_data());
-        $package->store_in_db($context->id);
+        redirect($thisurl, "HTTP Response code: " . $response->code, 500, \core\output\notification::NOTIFY_ERROR);
     }
+
+    // Store package_info in the DB.
+    $package = package::from_array($response->get_data());
+    $package->store_in_db($context->id);
 
     redirect($thisurl, "Package saved.", 500, \core\output\notification::NOTIFY_SUCCESS);
 } else {

--- a/upload_view.php
+++ b/upload_view.php
@@ -24,6 +24,7 @@
 
 use qtype_questionpy\package;
 use qtype_questionpy\api;
+use core\output\notification;
 
 require_once(dirname(__FILE__) . '/../../../config.php');
 
@@ -54,8 +55,10 @@ if ($mform->is_cancelled()) {
 } else if ($fromform = $mform->get_data()) {
     // File has been submitted in the form. Check if a file with this name already exists in this context.
     $filename = $mform->get_new_filename('qpy_package');
-    if ($fs->file_exists($context->id, 'qtype_questionpy', 'package', 0, '/', $filename)) {
-         redirect($thisurl, "File with this name already exists in this context.", 500, \core\output\notification::NOTIFY_WARNING);
+    if ($fs->file_exists($context->id, 'qtype_questionpy', 'package',
+        0, '/', $filename)) {
+        redirect($thisurl, "File with this name already exists in this context.", 500,
+            notification::NOTIFY_WARNING);
     }
 
     // Store file locally with the File API.
@@ -70,14 +73,15 @@ if ($mform->is_cancelled()) {
     if ($response->code != http_response_code(201)) {
         // If the file could not be saved on the server, also delete it in the file API.
         $storedfile->delete();
-        redirect($thisurl, "HTTP Response code: " . $response->code, 500, \core\output\notification::NOTIFY_ERROR);
+        redirect($thisurl, "HTTP Response code: " . $response->code, 500,
+            notification::NOTIFY_ERROR);
     }
 
     // Store package_info in the DB.
     $package = package::from_array($response->get_data());
     $package->store_in_db($context->id);
 
-    redirect($thisurl, "Package saved.", 500, \core\output\notification::NOTIFY_SUCCESS);
+     redirect($thisurl, "Package saved.", 500, notification::NOTIFY_SUCCESS);
 } else {
     $mform->display();
 }

--- a/upload_view.php
+++ b/upload_view.php
@@ -29,6 +29,7 @@ use qtype_questionpy\array_converter\array_converter;
 
 require_once(dirname(__FILE__) . '/../../../config.php');
 
+global $PAGE;
 $courseid = optional_param('courseid', 2, PARAM_INT);
 
 require_login($courseid);
@@ -71,7 +72,7 @@ if ($mform->is_cancelled()) {
         // Try to post the file to the server.
         $filesystem = $fs->get_file_system();
         $path = $filesystem->get_local_path_from_storedfile($storedfile, true);
-        $response = api::post_package($filename, $path);
+        $response = api::package_extract_info($filename, $path);
 
         if ($response->code != http_response_code(201)) {
             throw new moodle_exception("serverconnection", "error", "", null,
@@ -93,10 +94,11 @@ if ($mform->is_cancelled()) {
                 $errormessage = $errormessage . $ex->getMessage();
             }
         }
-        redirect($thisurl, $errormessage, 500, notification::NOTIFY_ERROR);
+        // redirect($thisurl, $errormessage, 500, notification::NOTIFY_ERROR);
+        notice($errormessage, $thisurl);
     }
-
-     redirect($thisurl, "Package saved.", 500, notification::NOTIFY_SUCCESS);
+    notice("Package saved.", $thisurl);
+    // redirect($thisurl, "Package saved.", 500, notification::NOTIFY_SUCCESS);
 } else {
     $mform->display();
 }


### PR DESCRIPTION
solves #19 

Neue route in der api: `post_package` entspricht `/packages/{hash} `serverseitig, wobei das berechnen des hash moodleseitig optional ist.

Die Form `package_upload`  übernimmt das Rendern der Pakete und nicht mehr die `upload_view`.