### PR TITLE
Form-Daten vom Server übernehmen

### DIFF
--- a/backup/moodle2/restore_qtype_questionpy_plugin.class.php
+++ b/backup/moodle2/restore_qtype_questionpy_plugin.class.php
@@ -59,8 +59,8 @@ class restore_qtype_questionpy_plugin extends restore_qtype_plugin {
         $oldid = $data->id;
 
         // Detect if the question is created or mapped.
-        $oldquestionid   = $this->get_old_parentid('question');
-        $newquestionid   = $this->get_new_parentid('question');
+        $oldquestionid = $this->get_old_parentid('question');
+        $newquestionid = $this->get_new_parentid('question');
         $questioncreated = (bool) $this->get_mappingid('question_created', $oldquestionid);
 
         // If the question has been created by restore, we need to create its qtype_questionpy too.

--- a/classes/api/question_edit_form_response.php
+++ b/classes/api/question_edit_form_response.php
@@ -1,0 +1,57 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\api;
+
+use qtype_questionpy\array_converter\array_converter;
+use qtype_questionpy\array_converter\converter_config;
+use qtype_questionpy\form\qpy_form;
+
+defined('MOODLE_INTERNAL') || die;
+
+/**
+ * Response from the server to a request for the question edit form.
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class question_edit_form_response {
+    /** @var qpy_form */
+    public qpy_form $definition;
+
+    /** @var array */
+    public array $formdata;
+
+    /**
+     * Initialize a new question response.
+     *
+     * @param qpy_form $definition form definition
+     * @param array $formdata      current values of the form elements
+     */
+    public function __construct(qpy_form $definition, array $formdata) {
+        $this->definition = $definition;
+        $this->formdata = $formdata;
+    }
+}
+
+array_converter::configure(question_edit_form_response::class, function (converter_config $config) {
+    $config
+        ->rename("formdata", "form_data");
+});
+
+

--- a/classes/array_converter/array_converter.php
+++ b/classes/array_converter/array_converter.php
@@ -183,7 +183,7 @@ class array_converter {
                 } else if (!$parameter->isVariadic()) {
                     throw new moodle_exception(
                         "cannotgetdata", "error", "", null,
-                        "No value provided for required field '$parameter->name'"
+                        "No value provided for required field '$parameter->name' of '{$reflect->getName()}'"
                     );
                 }
             }

--- a/classes/question_service.php
+++ b/classes/question_service.php
@@ -22,7 +22,7 @@ use qtype_questionpy\api\api;
 use stdClass;
 
 /**
- * Utility class for managing QuestionPy-specific question options in the DB.
+ * Manages QuestionPy-specific question options in the DB.
  *
  * @package    qtype_questionpy
  * @author     Maximilian Haye
@@ -51,8 +51,7 @@ class question_service {
      *
      * @param int $questionid ID of the question (`question.id`, not `qtype_questionpy.id`)
      * @return object QuestionPy-specific question fields in an associative array
-     * @throws dml_exception
-     * @throws \coding_exception
+     * @throws moodle_exception
      */
     public function get_question(int $questionid): object {
         global $DB;
@@ -67,15 +66,9 @@ class question_service {
                     " question {$questionid}"
                 );
             }
-            $result->qpy_package_hash = $package->hash;
 
+            $result->qpy_package_hash = $package->hash;
             $result->qpy_state = $record->state;
-            // TODO: Don't read options from state, let package include them in form response.
-            $state = json_decode($record->state, true);
-            // While moodle automagically parses names containing [] into objects, we have to do the reverse ourselves.
-            foreach (utils::flatten($state, "qpy_form") as $name => $value) {
-                $result->{$name} = $value;
-            }
         }
 
         return $result;

--- a/tests/question_service_test.php
+++ b/tests/question_service_test.php
@@ -31,20 +31,20 @@ use stdClass;
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class question_db_helper_test extends \advanced_testcase {
+class question_service_test extends \advanced_testcase {
 
     /** @var api */
     private api $api;
 
     /** @var question_service */
-    private question_service $questiondb;
+    private question_service $questionservice;
 
     protected function setUp(): void {
         $this->api = $this->createMock(api::class);
         $this->api->method("get_package")
             ->willReturn(null);
 
-        $this->questiondb = new question_service($this->api);
+        $this->questionservice = new question_service($this->api);
     }
 
     /**
@@ -54,17 +54,16 @@ class question_db_helper_test extends \advanced_testcase {
      * @throws coding_exception
      * @covers \qtype_questionpy\question_service::get_question
      */
-    public function test_get_question_should_load_options() {
+    public function test_get_question_should_load_package_and_state() {
         [$packageid, $package] = $this->setup_package();
         $statestr = $this->setup_question($packageid);
 
-        $result = $this->questiondb->get_question(1);
+        $result = $this->questionservice->get_question(1);
 
         $this->assertEquals(
             (object)[
                 "qpy_package_hash" => $package->hash,
                 "qpy_state" => $statestr,
-                "qpy_form[opt1]" => "opt 1 value",
             ], $result
         );
     }
@@ -78,7 +77,7 @@ class question_db_helper_test extends \advanced_testcase {
      * @covers \qtype_questionpy\question_service::get_question
      */
     public function test_get_question_should_return_empty_object_when_no_record() {
-        $this->assertEquals(new stdClass(), $this->questiondb->get_question(42));
+        $this->assertEquals(new stdClass(), $this->questionservice->get_question(42));
     }
 
     /**
@@ -103,7 +102,7 @@ class question_db_helper_test extends \advanced_testcase {
             ->with($newpackage->hash, $oldstate, (object) $formdata)
             ->willReturn(new question_response($newstate, "", ""));
 
-        $this->questiondb->upsert_question(
+        $this->questionservice->upsert_question(
             (object)[
                 "id" => 1,
                 "qpy_package_hash" => $newpackage->hash,
@@ -134,7 +133,7 @@ class question_db_helper_test extends \advanced_testcase {
             ->with($package->hash, $oldstate, (object) $formdata)
             ->willReturn(new question_response($oldstate, "", ""));
 
-        $this->questiondb->upsert_question(
+        $this->questionservice->upsert_question(
             (object)[
                 "id" => 1,
                 "qpy_package_hash" => $package->hash,
@@ -166,7 +165,7 @@ class question_db_helper_test extends \advanced_testcase {
             ->with($package->hash, null, (object) $formdata)
             ->willReturn(new question_response($newstate, "", ""));
 
-        $this->questiondb->upsert_question(
+        $this->questionservice->upsert_question(
             (object)[
                 "id" => 42, // Does not exist in the qtype_questionpy table yet.
                 "qpy_package_hash" => $package->hash,
@@ -189,7 +188,7 @@ class question_db_helper_test extends \advanced_testcase {
         $this->expectException(moodle_exception::class);
         $this->expectExceptionMessageMatches("/package $hash does not exist/");
 
-        $this->questiondb->upsert_question(
+        $this->questionservice->upsert_question(
             (object)[
                 "id" => 1,
                 "qpy_package_hash" => $hash,
@@ -211,7 +210,7 @@ class question_db_helper_test extends \advanced_testcase {
         global $DB;
         $this->assertEquals(1, $DB->count_records("qtype_questionpy"));
 
-        $this->questiondb->delete_question(1);
+        $this->questionservice->delete_question(1);
 
         $this->assertEquals(0, $DB->count_records("qtype_questionpy"));
     }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qtype_questionpy';
-$plugin->version   = 2022120101;
-$plugin->requires  = 2022041901;
-$plugin->maturity  = MATURITY_ALPHA;
-$plugin->release   = '0.1';
+$plugin->version = 2022120101;
+$plugin->requires = 2022041901;
+$plugin->maturity = MATURITY_ALPHA;
+$plugin->release = '0.1';


### PR DESCRIPTION
Auf den ersten Blick würde es auch funktionieren, in `definition_inner` `$this->question` zu bearbeiten. Vom PHPdoc her ist aber `set_data` der richtigere Ort dafür, deshalb mache ich das da.

Server-PR: https://github.com/questionpy-org/questionpy-server/pull/45
Common-PR: https://github.com/questionpy-org/questionpy-common/pull/11
SDK-PR: https://github.com/questionpy-org/questionpy-sdk/pull/33