### PR TITLE
Speichern von repetition_elements

### DIFF
--- a/classes/form/array_render_context.php
+++ b/classes/form/array_render_context.php
@@ -66,10 +66,10 @@ class array_render_context extends render_context {
      * Initializes a new array-based context.
      *
      * @param render_context $root context containing this group
-     * @param string $prefix prefix for the names of elements in this context
+     * @param string $prefix       prefix for the names of elements in this context
      */
     public function __construct(render_context $root, string $prefix) {
-        parent::__construct($root->moodleform, $root->mform, $prefix, $root->nextuniqueint);
+        parent::__construct($root->moodleform, $root->mform, $prefix, $root->data, $root->nextuniqueint);
     }
 
     /**

--- a/classes/form/array_render_context.php
+++ b/classes/form/array_render_context.php
@@ -16,6 +16,7 @@
 
 namespace qtype_questionpy\form;
 
+use HTML_QuickForm_element;
 use qtype_questionpy\form\conditions\condition;
 use qtype_questionpy\form\elements\group_element;
 use qtype_questionpy\form\elements\repetition_element;
@@ -36,7 +37,7 @@ use qtype_questionpy\utils;
  */
 class array_render_context extends render_context {
     /**
-     * @var array elements so far added to this group
+     * @var HTML_QuickForm_element[] elements so far added to this group
      */
     public array $elements = [];
     /**

--- a/classes/form/elements/repetition_element.php
+++ b/classes/form/elements/repetition_element.php
@@ -34,6 +34,8 @@ defined('MOODLE_INTERNAL') || die;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class repetition_element extends form_element {
+    /** @var string */
+    public string $name;
     /** @var int number of elements to show initially */
     public int $initialelements;
     /** @var int number of elements to add with each click of the button */
@@ -47,12 +49,15 @@ class repetition_element extends form_element {
     /**
      * Initializes the element.
      *
+     * @param string $name
      * @param int $initialelements number of elements to show initially
      * @param int $increment       number of elements to add with each click of the button
      * @param string $buttonlabel  label for the button which adds additional blanks
      * @param form_element[] $elements
      */
-    public function __construct(int $initialelements, int $increment, string $buttonlabel, array $elements) {
+    public function __construct(string $name, int $initialelements, int $increment, string $buttonlabel,
+                                array  $elements) {
+        $this->name = $name;
         $this->initialelements = $initialelements;
         $this->increment = $increment;
         $this->buttonlabel = $buttonlabel;
@@ -68,7 +73,7 @@ class repetition_element extends form_element {
     public function render_to(render_context $context): void {
         $innercontext = new array_render_context(
             $context,
-            $context->mangle_name("repetition_" . $context->next_unique_int())
+            $context->mangle_name($this->name)
         );
 
         foreach ($this->elements as $element) {

--- a/classes/form/form_section.php
+++ b/classes/form/form_section.php
@@ -62,8 +62,7 @@ class form_section implements renderable {
     public function render_to(render_context $context): void {
         $mangled = $context->mangle_name($this->name);
         $context->add_element("header", $mangled, $this->header);
-        $innercontext = new root_render_context($context->moodleform, $context->mform, $mangled,
-                                                $context->nextuniqueint);
+        $innercontext = root_render_context::create_inner($context, $this->name);
         foreach ($this->elements as $element) {
             $element->render_to($innercontext);
         }

--- a/classes/form/render_context.php
+++ b/classes/form/render_context.php
@@ -48,9 +48,10 @@ abstract class render_context {
     /** @var string prefix for rendered element names */
     public string $prefix;
 
-    /**
-     * @var int the next int which will be returned by {@see next_unique_int}
-     */
+    /** @var array the current form data */
+    public array $data;
+
+    /** @var int the next int which will be returned by {@see next_unique_int} */
     public int $nextuniqueint;
 
     /**
@@ -60,13 +61,15 @@ abstract class render_context {
      * @param MoodleQuickForm $mform  target {@see MoodleQuickForm} instance, as passed to
      *                                {@see \question_edit_form::definition_inner}
      * @param string $prefix          prefix for the names of elements in this context
+     * @param array $data             the current form data (as of last save)
      * @param int $nextuniqueint      the starting value for {@see next_unique_int}
      */
-    public function __construct(moodleform $moodleform, MoodleQuickForm $mform, string $prefix,
+    public function __construct(moodleform $moodleform, MoodleQuickForm $mform, string $prefix, array $data,
                                 int        $nextuniqueint = 1) {
         $this->moodleform = $moodleform;
         $this->mform = $mform;
         $this->prefix = $prefix;
+        $this->data = $data;
         $this->nextuniqueint = $nextuniqueint;
     }
 
@@ -155,6 +158,14 @@ abstract class render_context {
         if (utils::str_starts_with($name, $this->prefix)) {
             // Already mangled, perhaps by an array_render_context.
             return $name;
+        }
+
+        $firstbrace = strpos($name, "[");
+        if ($firstbrace) {
+            // We want to turn abc[def] into prefix[abc][def], not prefix[abc[def]].
+            $beforebrace = substr($name, 0, $firstbrace);
+            $afterbrace = substr($name, $firstbrace);
+            return $this->prefix . "[$beforebrace]" . $afterbrace;
         }
 
         return $this->prefix . "[$name]";

--- a/classes/form/root_render_context.php
+++ b/classes/form/root_render_context.php
@@ -17,6 +17,7 @@
 namespace qtype_questionpy\form;
 
 use qtype_questionpy\form\conditions\condition;
+use qtype_questionpy\utils;
 
 /**
  * Regular {@see render_context} which delegates to {@see \moodleform} and {@see \MoodleQuickForm}.
@@ -29,6 +30,20 @@ use qtype_questionpy\form\conditions\condition;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class root_render_context extends render_context {
+    /**
+     * Creates an inner context by adding `$name` to the prefix and using `$data[$name]`.
+     *
+     * @param render_context $parent
+     * @param string $name nested name to be added to the prefix. May be made up of `multiple[parts]`.
+     * @return static
+     */
+    public static function create_inner(render_context $parent, string $name): self {
+        return new root_render_context(
+            $parent->moodleform, $parent->mform, $parent->mangle_name($name),
+            utils::array_get_nested($parent->data, $name) ?? [], $parent->nextuniqueint
+        );
+    }
+
     /**
      * Create, add and return an element.
      *

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -55,10 +55,17 @@ class utils {
         return substr_compare($haystack, $needle, 0, strlen($needle)) === 0;
     }
 
+    public static function str_remove_prefix(string $haystack, string $prefix): string {
+        if (self::str_starts_with($haystack, $prefix)) {
+            return substr($haystack, strlen($prefix));
+        }
+        return $haystack;
+    }
+
     /**
      * Given an array with possible nested arrays, generates flat entries keys reflect the paths in the input array.
      *
-     * @param array $source input array which might contain nested arrays
+     * @param array $source  input array which might contain nested arrays
      * @param string $prefix prefix for all returned keys, as if `$source` where nested in an array with that key
      * @return Generator<string, mixed> flat generator of entries
      */

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -55,13 +55,6 @@ class utils {
         return substr_compare($haystack, $needle, 0, strlen($needle)) === 0;
     }
 
-    public static function str_remove_prefix(string $haystack, string $prefix): string {
-        if (self::str_starts_with($haystack, $prefix)) {
-            return substr($haystack, strlen($prefix));
-        }
-        return $haystack;
-    }
-
     /**
      * Given an array with possible nested arrays, generates flat entries keys reflect the paths in the input array.
      *
@@ -78,5 +71,29 @@ class utils {
                 yield $fullkey => $value;
             }
         }
+    }
+
+    /**
+     * Given an array and a key such as `abc[def]`, returns `$array["abc"]["def"]`.
+     *
+     * If any of the key's parts don't exist or resolve to null, this function returns null.
+     *
+     * @param array $array
+     * @param string $key
+     * @return mixed
+     */
+    public static function array_get_nested(array $array, string $key) {
+        // Explode a $name like qpy_form[abc][def] into an array ["qpy_form", "abc", "def"].
+        $parts = explode("[", str_replace("]", "", $key));
+
+        $current = $array;
+        foreach ($parts as $key) {
+            $current = $current[$key] ?? null;
+            if ($current === null) {
+                return null;
+            }
+        }
+
+        return $current;
     }
 }

--- a/edit_questionpy_form.php
+++ b/edit_questionpy_form.php
@@ -105,12 +105,15 @@ class qtype_questionpy_edit_form extends question_edit_form {
         $mform->addElement("hidden", "package_changed", "true", ["disabled" => "disabled"]);
         $mform->setType("package_changed", PARAM_RAW);
 
-        $packagehash = $this->optional_param("qpy_package_hash", $this->question->qpy_package_hash ?? null,
-            PARAM_ALPHANUM);
+        $packagehash = $this->optional_param(
+            "qpy_package_hash",
+            $this->question->qpy_package_hash ?? null, PARAM_ALPHANUM
+        );
         if ($packagehash) {
-            // A package is selected -> render its form.
             $response = $api->get_question_edit_form($packagehash, $this->question->qpy_state ?? null);
-            $response->definition->render_to(new root_render_context($this, $mform, "qpy_form"));
+
+            $context = new root_render_context($this, $mform, "qpy_form", $response->formdata);
+            $response->definition->render_to($context);
 
             // Used by set_data.
             $this->currentdata = $response->formdata;

--- a/tests/form/elements/element_html_test.php
+++ b/tests/form/elements/element_html_test.php
@@ -77,7 +77,6 @@ class element_html_test extends \advanced_testcase {
      * Provides argument pairs for {@see test_rendered_html_should_match_snapshot}.
      */
     public function data_provider(): array {
-        // No repetition_element - see FIXME in repetition_element::render_to.
         return [
             ["checkbox.html", new checkbox_element("my_checkbox", "Left", "Right", true, true)],
             ["checkbox_group.html", new checkbox_group_element(
@@ -95,6 +94,9 @@ class element_html_test extends \advanced_testcase {
                 new option("Option 1", "opt1", true),
                 new option("Option 2", "opt2"),
             ], true)],
+            ["repetition.html", new repetition_element("my_rep", 3, 2, null, [
+                new text_input_element("item", "Label"),
+            ])],
             ["select.html", new select_element("my_select", "Label", [
                 new option("Option 1", "opt1", true),
                 new option("Option 2", "opt2"),

--- a/tests/form/elements/element_json_test.php
+++ b/tests/form/elements/element_json_test.php
@@ -97,7 +97,7 @@ class element_json_test extends \advanced_testcase {
                 new option("Option 1", "opt1", true),
                 new option("Option 2", "opt2"),
             ], true))->disable_if(new does_not_equal("input1", ""))],
-            ["repetition.json", new repetition_element(3, 2, "", [
+            ["repetition.json", new repetition_element("my_repetition", 3, 2, "", [
                 new text_input_element("item", ""),
             ])],
             ["select.json", (new select_element("my_select", "Label", [

--- a/tests/form/elements/element_json_test.php
+++ b/tests/form/elements/element_json_test.php
@@ -97,7 +97,7 @@ class element_json_test extends \advanced_testcase {
                 new option("Option 1", "opt1", true),
                 new option("Option 2", "opt2"),
             ], true))->disable_if(new does_not_equal("input1", ""))],
-            ["repetition.json", new repetition_element("my_repetition", 3, 2, "", [
+            ["repetition.json", new repetition_element("my_rep", 3, 2, "", [
                 new text_input_element("item", ""),
             ])],
             ["select.json", (new select_element("my_select", "Label", [

--- a/tests/form/elements/html/repetition.html
+++ b/tests/form/elements/html/repetition.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
 <html><body><form id="my_form" autocomplete="off" action="" method="post" accept-charset="utf-8" class="mform">
-	<div style="display: none;"><input name="repeats" type="hidden" value="3">
+	<div style="display: none;"><input name="qpy_repeats_my_rep" type="hidden" value="3">
 <input name="sesskey" type="hidden" value="sesskey">
 <input name="_qf__qtype_questionpy_form_elements_test_moodleform" type="hidden" value="1">
 </div>
 
-<div id="fitem_id_qpy_form_repetition_1_item_0" class="form-group row  fitem   ">
+<div id="fitem_id_qpy_form_my_rep_0_item" class="form-group row  fitem   ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
-                <label id="id_qpy_form_repetition_1_item_0_label" class="d-inline word-break " for="id_qpy_form_repetition_1_item_0">
-                    Item 1
+                <label id="id_qpy_form_my_rep_0_item_label" class="d-inline word-break " for="id_qpy_form_my_rep_0_item">
+                    Label
                 </label>
         
         <div class="form-label-addon d-flex align-items-center align-self-start">
@@ -17,16 +17,16 @@
         </div>
     </div>
     <div class="col-md-9 form-inline align-items-start felement" data-fieldtype="text">
-        <input type="text" class="form-control " name="qpy_form[repetition_1][item][0]" id="id_qpy_form_repetition_1_item_0" value="">
-        <div class="form-control-feedback invalid-feedback" id="id_error_qpy_form_repetition_1_item_0">
+        <input type="text" class="form-control " name="qpy_form[my_rep][0][item]" id="id_qpy_form_my_rep_0_item" value="">
+        <div class="form-control-feedback invalid-feedback" id="id_error_qpy_form_my_rep_0_item">
             
         </div>
     </div>
-</div><div id="fitem_id_qpy_form_repetition_1_item_1" class="form-group row  fitem   ">
+</div><div id="fitem_id_qpy_form_my_rep_1_item" class="form-group row  fitem   ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
-                <label id="id_qpy_form_repetition_1_item_1_label" class="d-inline word-break " for="id_qpy_form_repetition_1_item_1">
-                    Item 2
+                <label id="id_qpy_form_my_rep_1_item_label" class="d-inline word-break " for="id_qpy_form_my_rep_1_item">
+                    Label
                 </label>
         
         <div class="form-label-addon d-flex align-items-center align-self-start">
@@ -34,16 +34,16 @@
         </div>
     </div>
     <div class="col-md-9 form-inline align-items-start felement" data-fieldtype="text">
-        <input type="text" class="form-control " name="qpy_form[repetition_1][item][1]" id="id_qpy_form_repetition_1_item_1" value="">
-        <div class="form-control-feedback invalid-feedback" id="id_error_qpy_form_repetition_1_item_1">
+        <input type="text" class="form-control " name="qpy_form[my_rep][1][item]" id="id_qpy_form_my_rep_1_item" value="">
+        <div class="form-control-feedback invalid-feedback" id="id_error_qpy_form_my_rep_1_item">
             
         </div>
     </div>
-</div><div id="fitem_id_qpy_form_repetition_1_item_2" class="form-group row  fitem   ">
+</div><div id="fitem_id_qpy_form_my_rep_2_item" class="form-group row  fitem   ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
-                <label id="id_qpy_form_repetition_1_item_2_label" class="d-inline word-break " for="id_qpy_form_repetition_1_item_2">
-                    Item 3
+                <label id="id_qpy_form_my_rep_2_item_label" class="d-inline word-break " for="id_qpy_form_my_rep_2_item">
+                    Label
                 </label>
         
         <div class="form-label-addon d-flex align-items-center align-self-start">
@@ -51,12 +51,12 @@
         </div>
     </div>
     <div class="col-md-9 form-inline align-items-start felement" data-fieldtype="text">
-        <input type="text" class="form-control " name="qpy_form[repetition_1][item][2]" id="id_qpy_form_repetition_1_item_2" value="">
-        <div class="form-control-feedback invalid-feedback" id="id_error_qpy_form_repetition_1_item_2">
+        <input type="text" class="form-control " name="qpy_form[my_rep][2][item]" id="id_qpy_form_my_rep_2_item" value="">
+        <div class="form-control-feedback invalid-feedback" id="id_error_qpy_form_my_rep_2_item">
             
         </div>
     </div>
-</div><div id="fitem_id_add_repeats" class="form-group row  fitem femptylabel  ">
+</div><div id="fitem_id_qpy_repeat_add_more_my_rep" class="form-group row  fitem femptylabel  ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
         <div class="form-label-addon d-flex align-items-center align-self-start">
@@ -69,8 +69,8 @@
                         btn-secondary
                     
                     
-                    " name="add_repeats" id="id_add_repeats" value="Add 2 more" data-skip-validation="1" data-no-submit="1" onclick="skipClientValidation = true;">
-        <div class="form-control-feedback invalid-feedback" id="id_error_add_repeats">
+                    " name="qpy_repeat_add_more_my_rep" id="id_qpy_repeat_add_more_my_rep" value="Add 2 field(s) to form">
+        <div class="form-control-feedback invalid-feedback" id="id_error_qpy_repeat_add_more_my_rep">
             
         </div>
     </div>

--- a/tests/form/elements/json/repetition.json
+++ b/tests/form/elements/json/repetition.json
@@ -1,5 +1,6 @@
 {
   "kind": "repetition",
+  "name": "my_rep",
   "initial_elements": 3,
   "increment": 2,
   "button_label": "",

--- a/tests/form/elements/test_moodleform.php
+++ b/tests/form/elements/test_moodleform.php
@@ -54,7 +54,7 @@ class test_moodleform extends \moodleform {
      * Output can be retrieved using {@see render}, which calls this method.
      */
     protected function definition() {
-        $context = new root_render_context($this, $this->_form, "qpy_form");
+        $context = new root_render_context($this, $this->_form, "qpy_form", []);
         $this->element->render_to($context);
     }
 }


### PR DESCRIPTION
Gar nicht mal so trivial.
* Moodle's eigenes `moodleform::repeat_elements()` hat das Problem, dass es inkonsistente Namen für die fertigen Elemente generiert: Das Element heißt dann z.B. `qpy_form[repetition_1][name][0]`, dann wird aber versucht, den Typen des Elements `qpy_form[0][repetition_1][name]` zu setzen. Keine der beiden Varianten wollen wir. Wenn in Python `repetition_1: list[MyFormModel]` draus werden soll, muss der Name `qpy_form[repetition_1][0][name]` sein.

  Hier könnte man theoretisch versuchen, im Nachhinein die Elemente umzubenennen. Das wäre aber unschön, kompliziert und fehleranfällig. Stattdessen habe ich `repeat_elements` durch eine eigene Implementierung ersetzt. Interessanterweise hat `render_to` dadurch jetzt weniger Zeilen :clown_face: 

  Was der neuen Impl im Vergleich zu `repeat_elements` fehlt, ist:
  * Die Möglichkeit, dass `{no}` in Labels & co. durch die Nummer der Wiederholung ersetzt wird. Das ist bestimmt nicht so schwer nachzuziehen. Frage ist, ob wir es genauso machen wollen (`{no}`)?
  * Die Möglichkeit, einen (auf anderem Wege hinzugefügten) Button als Delete-Button zu markieren, der dann Wiederholungen entfernt. Wollen wir das auf gleichem Wege lösen?
* Nachdem die Form verlassen wird, ist die Anzahl der Wiederholungen nur im State gespeichert (implizit als Länge des Arrays), woraus dann die Form-Daten gemacht werden. Diese muss jedoch aus `render_to` verfügbar sein, was bisher nicht der Fall war. Jetzt schleifen die `render_contexts` noch ein `array $data` mit, das aus `question_edit_form_response->formdata` kommt. Daraus wird die aktuelle Anzahl entnommen.
* Werden Wiederholungen hinzugefügt, die dann nicht befüllt werden, landen sie mit ihren Default-Werten (z.B. `""`) in den Form-Daten (statt gar nicht). Das war auch mit `repeat_elements` so.

Aus
```python
class MyRep(FormModel):
    my_input: Optional[str] = text_input("Abc")

class MyMainModel(FormModel):
    my_rep: list[MyRep] = repeat(MyRep, 1, 2)
```

wird jetzt also bspw.

```json
{
  "my_rep": [
    {
      "my_input": "Wert 1"
    },
    {
      "my_input": "Wert 2"
    },
    {
      "my_input": ""
    }
  ]
}
```