### PR TITLE
Relative Referenzen in Bedingungen

### DIFF
--- a/classes/form/array_render_context.php
+++ b/classes/form/array_render_context.php
@@ -54,11 +54,12 @@ class array_render_context extends render_context {
      */
     public array $rules = [];
     /**
-     * @var condition[] associative array of element names to conditions which should disable the named element
+     * @var array associative array of dependant names to [dependency name, operator, value] arrays which should disable
+     *      the named element
      */
     public array $disableifs = [];
     /**
-     * @var condition[] associative array of element names to conditions which should hide the named element
+     * @var array same as $disableifs, but for hiding elements
      */
     public array $hideifs = [];
 
@@ -136,22 +137,26 @@ class array_render_context extends render_context {
      * Adds a condition which will disable the named element if met.
      *
      * @param string $dependant name of the element which has the dependency on another element
-     * @param condition $condition
+     * @param string $dependency  absolute name of the element which is depended on
+     * @param string $operator  one of a fixed set of conditions, as in {@see MoodleQuickForm::disabledIf}
+     * @param mixed $value      for conditions requiring it, the value to compare with. Ignored otherwise.
      * @see \MoodleQuickForm::disabledIf()
      */
-    public function disable_if(string $dependant, condition $condition) {
-        utils::ensure_exists($this->disableifs, $this->mangle_name($dependant))[] = $condition;
+    public function disable_if(string $dependant, string $dependency, string $operator, $value = null) {
+        utils::ensure_exists($this->disableifs, $this->mangle_name($dependant))[] = [$dependency, $operator, $value];
     }
 
     /**
      * Adds a condition which will hide the named element if met.
      *
      * @param string $dependant name of the element which has the dependency on another element
-     * @param condition $condition
+     * @param string $dependency  absolute name of the element which is depended on
+     * @param string $operator  one of a fixed set of conditions, as in {@see MoodleQuickForm::hideIf}
+     * @param mixed $value      for conditions requiring it, the value to compare with. Ignored otherwise.
      * @see \MoodleQuickForm::hideIf()
      */
-    public function hide_if(string $dependant, condition $condition) {
-        utils::ensure_exists($this->hideifs, $this->mangle_name($dependant))[] = $condition;
+    public function hide_if(string $dependant, string $dependency, string $operator, $value = null) {
+        utils::ensure_exists($this->hideifs, $this->mangle_name($dependant))[] = [$dependency, $operator, $value];
     }
 
     /**

--- a/classes/form/conditions/condition.php
+++ b/classes/form/conditions/condition.php
@@ -44,12 +44,12 @@ abstract class condition {
     }
 
     /**
-     * Return the `[$condition]` or `[$condition, $value]` tuple  to pass to {@see \MoodleQuickForm::disabledIf()} or
-     * {@see \MoodleQuickForm::hideIf()} after the depended on element's name.
+     * Return the condition string to pass to {@see \MoodleQuickForm::disabledIf()} or {@see \MoodleQuickForm::hideIf()}
+     * after the depended on element's name.
      *
-     * @return array
+     * @return string
      */
-    abstract public function to_mform_args(): array;
+    abstract public static function mform_type(): string;
 }
 
 array_converter::configure(condition::class, function (converter_config $config) {

--- a/classes/form/conditions/does_not_equal.php
+++ b/classes/form/conditions/does_not_equal.php
@@ -27,12 +27,12 @@ namespace qtype_questionpy\form\conditions;
 class does_not_equal extends condition_with_value {
 
     /**
-     * Return the `[$condition]` or `[$condition, $value]` tuple  to pass to {@see \MoodleQuickForm::disabledIf()} or
-     * {@see \MoodleQuickForm::hideIf()} after the depended on element's name.
+     * Return the condition string to pass to {@see \MoodleQuickForm::disabledIf()} or {@see \MoodleQuickForm::hideIf()}
+     * after the depended on element's name.
      *
-     * @return array
+     * @return string
      */
-    public function to_mform_args(): array {
-        return ["neq", $this->value];
+    public static function mform_type(): string {
+        return "neq";
     }
 }

--- a/classes/form/conditions/equals.php
+++ b/classes/form/conditions/equals.php
@@ -27,12 +27,12 @@ namespace qtype_questionpy\form\conditions;
 class equals extends condition_with_value {
 
     /**
-     * Return the `[$condition]` or `[$condition, $value]` tuple  to pass to {@see \MoodleQuickForm::disabledIf()} or
-     * {@see \MoodleQuickForm::hideIf()} after the depended on element's name.
+     * Return the condition string to pass to {@see \MoodleQuickForm::disabledIf()} or {@see \MoodleQuickForm::hideIf()}
+     * after the depended on element's name.
      *
-     * @return array
+     * @return string
      */
-    public function to_mform_args(): array {
-        return ["eq", $this->value];
+    public static function mform_type(): string {
+        return "eq";
     }
 }

--- a/classes/form/conditions/in.php
+++ b/classes/form/conditions/in.php
@@ -27,12 +27,12 @@ namespace qtype_questionpy\form\conditions;
 class in extends condition_with_value {
 
     /**
-     * Return the `[$condition]` or `[$condition, $value]` tuple  to pass to {@see \MoodleQuickForm::disabledIf()} or
-     * {@see \MoodleQuickForm::hideIf()} after the depended on element's name.
+     * Return the condition string to pass to {@see \MoodleQuickForm::disabledIf()} or {@see \MoodleQuickForm::hideIf()}
+     * after the depended on element's name.
      *
-     * @return array
+     * @return string
      */
-    public function to_mform_args(): array {
-        return ["in", $this->value];
+    public static function mform_type(): string {
+        return "in";
     }
 }

--- a/classes/form/conditions/is_checked.php
+++ b/classes/form/conditions/is_checked.php
@@ -27,12 +27,12 @@ namespace qtype_questionpy\form\conditions;
 class is_checked extends condition {
 
     /**
-     * Return the `[$condition]` or `[$condition, $value]` tuple  to pass to {@see \MoodleQuickForm::disabledIf()} or
-     * {@see \MoodleQuickForm::hideIf()} after the depended on element's name.
+     * Return the condition string to pass to {@see \MoodleQuickForm::disabledIf()} or {@see \MoodleQuickForm::hideIf()}
+     * after the depended on element's name.
      *
-     * @return array
+     * @return string
      */
-    public function to_mform_args(): array {
-        return ["checked"];
+    public static function mform_type(): string {
+        return "checked";
     }
 }

--- a/classes/form/conditions/is_not_checked.php
+++ b/classes/form/conditions/is_not_checked.php
@@ -27,12 +27,12 @@ namespace qtype_questionpy\form\conditions;
 class is_not_checked extends condition {
 
     /**
-     * Return the `[$condition]` or `[$condition, $value]` tuple  to pass to {@see \MoodleQuickForm::disabledIf()} or
-     * {@see \MoodleQuickForm::hideIf()} after the depended on element's name.
+     * Return the condition string to pass to {@see \MoodleQuickForm::disabledIf()} or {@see \MoodleQuickForm::hideIf()}
+     * after the depended on element's name.
      *
-     * @return array
+     * @return string
      */
-    public function to_mform_args(): array {
-        return ["notchecked"];
+    public static function mform_type(): string {
+        return "notchecked";
     }
 }

--- a/classes/form/elements/group_element.php
+++ b/classes/form/elements/group_element.php
@@ -78,11 +78,16 @@ class group_element extends form_element {
         foreach ($innercontext->defaults as $name => $default) {
             $context->set_default($name, $default);
         }
-        foreach ($innercontext->disableifs as $name => $condition) {
-            $context->disable_if($name, $condition);
+
+        foreach ($innercontext->disableifs as $name => $conditions) {
+            foreach ($conditions as $condition) {
+                $context->disable_if($name, ...$condition);
+            }
         }
-        foreach ($innercontext->hideifs as $name => $condition) {
-            $context->hide_if($name, $condition);
+        foreach ($innercontext->hideifs as $name => $conditions) {
+            foreach ($conditions as $condition) {
+                $context->hide_if($name, ...$condition);
+            }
         }
 
         $context->mform->addGroupRule($groupname, $innercontext->rules);

--- a/classes/form/form_conditions.php
+++ b/classes/form/form_conditions.php
@@ -44,11 +44,13 @@ trait form_conditions {
      */
     private function render_conditions(render_context $context, string $name) {
         foreach ($this->disableif as $disableif) {
-            $context->disable_if($name, $disableif);
+            $dependency = $context->reference_to_absolute($disableif->name);
+            $context->disable_if($name, $dependency, $disableif->mform_type(), $disableif->value ?? null);
         }
 
         foreach ($this->hideif as $hideif) {
-            $context->hide_if($name, $hideif);
+            $dependency = $context->reference_to_absolute($hideif->name);
+            $context->hide_if($name, $dependency, $hideif->mform_type(), $hideif->value ?? null);
         }
     }
 

--- a/classes/form/root_render_context.php
+++ b/classes/form/root_render_context.php
@@ -104,22 +104,26 @@ class root_render_context extends render_context {
      * Adds a condition which will disable the named element if met.
      *
      * @param string $dependant name of the element which has the dependency on another element
-     * @param condition $condition
+     * @param string $dependency  absolute name of the element which is depended on
+     * @param string $operator  one of a fixed set of conditions, as in {@see MoodleQuickForm::disabledIf}
+     * @param mixed $value      for conditions requiring it, the value to compare with. Ignored otherwise.
      * @see \MoodleQuickForm::disabledIf()
      */
-    public function disable_if(string $dependant, condition $condition) {
-        $this->mform->disabledIf($this->mangle_name($dependant), $condition->name, ...$condition->to_mform_args());
+    public function disable_if(string $dependant, string $dependency, string $operator, $value = null) {
+        $this->mform->disabledIf($this->mangle_name($dependant), $dependency, $operator, $value);
     }
 
     /**
      * Adds a condition which will hide the named element if met.
      *
      * @param string $dependant name of the element which has the dependency on another element
-     * @param condition $condition
+     * @param string $dependency  absolute name of the element which is depended on
+     * @param string $operator  one of a fixed set of conditions, as in {@see MoodleQuickForm::hideIf}
+     * @param mixed $value      for conditions requiring it, the value to compare with. Ignored otherwise.
      * @see \MoodleQuickForm::hideIf()
      */
-    public function hide_if(string $dependant, condition $condition) {
-        $this->mform->hideIf($this->mangle_name($dependant), $condition->name, ...$condition->to_mform_args());
+    public function hide_if(string $dependant, string $dependency, string $operator, $value = null) {
+        $this->mform->hideIf($this->mangle_name($dependant), $dependency, $operator, $value);
     }
 
     /**


### PR DESCRIPTION
Gegenstück zu questionpy-org/questionpy-sdk#40.

Der Einfachheit halber setze ich hier einfach die absolute Referenz zusammen und prüfe nicht, ob das Ziel auch wirklich existiert o.ä.. Das sollte durch die SDK geprüft werden. Sollte ein Paket validate_form umgehen, sehe ich darin kein Sicherheitsrisiko. Die Form würde einfach nicht richtig funktionieren.