### PR TITLE
Hilfetexte für Form-Elemente

### DIFF
--- a/classes/api/question_response.php
+++ b/classes/api/question_response.php
@@ -37,13 +37,13 @@ class question_response {
     public string $statehash;
 
     /** @var string */
-    public string $gradingmethod;
+    public string $scoringmethod;
 
     /** @var float|int */
-    public float $grademinfraction = 0;
+    public float $scoremin = 0;
 
     /** @var float|int */
-    public float $grademaxfraction = 1;
+    public float $scoremax = 1;
 
     /** @var float|null */
     public ?float $penalty = null;
@@ -62,12 +62,12 @@ class question_response {
      *
      * @param string $state     new question state
      * @param string $statehash hash of `$state`
-     * @param string $gradingmethod
+     * @param string $scoringmethod
      */
-    public function __construct(string $state, string $statehash, string $gradingmethod) {
+    public function __construct(string $state, string $statehash, string $scoringmethod) {
         $this->state = $state;
         $this->statehash = $statehash;
-        $this->gradingmethod = $gradingmethod;
+        $this->scoringmethod = $scoringmethod;
     }
 }
 
@@ -75,9 +75,9 @@ array_converter::configure(question_response::class, function (converter_config 
     $config
         ->rename("state", "question_state")
         ->rename("statehash", "question_state_hash")
-        ->rename("gradingmethod", "grading_method")
-        ->rename("grademinfraction", "grade_min_fraction")
-        ->rename("grademaxfraction", "grade_max_fraction")
+        ->rename("scoringmethod", "scoring_method")
+        ->rename("scoremin", "score_min")
+        ->rename("scoremax", "score_max")
         ->rename("randomguessscore", "random_guess_score")
         ->rename("rendereveryview", "render_every_view")
         ->rename("generalfeedback", "general_feedback");

--- a/classes/form/dynamic_help_icon.php
+++ b/classes/form/dynamic_help_icon.php
@@ -1,0 +1,93 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\form;
+
+use coding_exception;
+use core\output\named_templatable;
+use renderable;
+use renderer_base;
+use stdClass;
+
+/**
+ * Like {@see \help_icon}, but with text provided as properties instead of requiring the use of lang strings.
+ *
+ * Uses the same template as the original {@see \help_icon}. Render using {@see renderer_base::render()} as set an
+ * element's `_helpbutton` property to the resulting HTML.
+ *
+ * @see        \MoodleQuickForm::addHelpButton()
+ * @see        form_help
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class dynamic_help_icon implements renderable, named_templatable {
+
+    /** @var string|null */
+    private ?string $title;
+    /** @var string */
+    private string $text;
+
+    /**
+     * Initializes a new instance.
+     *
+     * @param string $text       the main help text shown as a popover when the help icon is clicked.
+     * @param string|null $title if given, the icon's alt text (which is shown when hovering over it) will be set to
+     *                           "Help with $title" (`helpprefix2`). Otherwise, "Help with this" (`helpwiththis`) is
+     *                           used.
+     */
+    public function __construct(string $text, ?string $title = null) {
+        $this->text = $text;
+        $this->title = $title;
+    }
+
+    /**
+     * Get the name of the template to use for this templatable.
+     *
+     * @param \renderer_base $renderer The renderer requesting the template name
+     * @return string
+     */
+    public function get_template_name(\renderer_base $renderer): string {
+        return "core/help_icon";
+    }
+
+    /**
+     * Function to export the renderer data in a format that is suitable for a
+     * mustache template. This means:
+     * 1. No complex types - only stdClass, array, int, string, float, bool
+     * 2. Any additional info that is required for the template is pre-calculated (e.g. capability checks).
+     *
+     * @param renderer_base $output Used to do a final render of any components that need to be rendered for export.
+     * @return stdClass
+     * @throws coding_exception
+     */
+    public function export_for_template(renderer_base $output): object {
+        $data = new stdClass();
+
+        $data->text = $this->text;
+        $data->ltr = !right_to_left();
+
+        if ($this->title) {
+            $data->alt = get_string('helpprefix2', '', trim($this->title, ". \t"));
+        } else {
+            $data->alt = get_string('helpwiththis');
+        }
+
+        return $data;
+    }
+}

--- a/classes/form/elements/checkbox_element.php
+++ b/classes/form/elements/checkbox_element.php
@@ -16,9 +16,11 @@
 
 namespace qtype_questionpy\form\elements;
 
+use coding_exception;
 use qtype_questionpy\array_converter\array_converter;
 use qtype_questionpy\array_converter\converter_config;
 use qtype_questionpy\form\form_conditions;
+use qtype_questionpy\form\form_help;
 use qtype_questionpy\form\render_context;
 
 defined('MOODLE_INTERNAL') || die;
@@ -43,7 +45,7 @@ class checkbox_element extends form_element {
     /** @var bool */
     public bool $selected = false;
 
-    use form_conditions;
+    use form_conditions, form_help;
 
     /**
      * Initializes the element.
@@ -69,9 +71,10 @@ class checkbox_element extends form_element {
      * @param render_context $context target context
      * @param int|null $group         passed by {@see checkbox_group_element::render_to} to the checkboxes belonging to
      *                                it
+     * @throws coding_exception
      */
     public function render_to(render_context $context, ?int $group = null): void {
-        $context->add_element(
+        $element = $context->add_element(
             "advcheckbox", $this->name, $this->leftlabel, $this->rightlabel,
             $group ? ["group" => $group] : null
         );
@@ -84,6 +87,7 @@ class checkbox_element extends form_element {
         }
 
         $this->render_conditions($context, $this->name);
+        $this->render_help($element);
     }
 }
 

--- a/classes/form/elements/checkbox_group_element.php
+++ b/classes/form/elements/checkbox_group_element.php
@@ -16,6 +16,7 @@
 
 namespace qtype_questionpy\form\elements;
 
+use coding_exception;
 use qtype_questionpy\array_converter\array_converter;
 use qtype_questionpy\array_converter\converter_config;
 use qtype_questionpy\form\render_context;
@@ -47,6 +48,7 @@ class checkbox_group_element extends form_element {
      * Render this item to the given context.
      *
      * @param render_context $context target context
+     * @throws coding_exception
      * @package qtype_questionpy
      */
     public function render_to(render_context $context): void {

--- a/classes/form/elements/form_element.php
+++ b/classes/form/elements/form_element.php
@@ -18,7 +18,7 @@ namespace qtype_questionpy\form\elements;
 
 use qtype_questionpy\array_converter\array_converter;
 use qtype_questionpy\array_converter\converter_config;
-use qtype_questionpy\form\renderable;
+use qtype_questionpy\form\qpy_renderable;
 
 defined('MOODLE_INTERNAL') || die;
 
@@ -30,7 +30,7 @@ defined('MOODLE_INTERNAL') || die;
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-abstract class form_element implements renderable {
+abstract class form_element implements qpy_renderable {
 }
 
 array_converter::configure(form_element::class, function (converter_config $config) {

--- a/classes/form/elements/group_element.php
+++ b/classes/form/elements/group_element.php
@@ -20,6 +20,7 @@ use qtype_questionpy\array_converter\array_converter;
 use qtype_questionpy\array_converter\converter_config;
 use qtype_questionpy\form\array_render_context;
 use qtype_questionpy\form\form_conditions;
+use qtype_questionpy\form\form_help;
 use qtype_questionpy\form\render_context;
 
 defined('MOODLE_INTERNAL') || die;
@@ -41,7 +42,7 @@ class group_element extends form_element {
     /** @var form_element[] */
     public array $elements;
 
-    use form_conditions;
+    use form_conditions, form_help;
 
     /**
      * Initializes the element.
@@ -70,7 +71,7 @@ class group_element extends form_element {
             $element->render_to($innercontext);
         }
 
-        $context->add_element("group", $groupname, $this->label, $innercontext->elements, null, false);
+        $element = $context->add_element("group", $groupname, $this->label, $innercontext->elements, null, false);
 
         foreach ($innercontext->types as $name => $type) {
             $context->set_type($name, $type);
@@ -93,6 +94,7 @@ class group_element extends form_element {
         $context->mform->addGroupRule($groupname, $innercontext->rules);
 
         $this->render_conditions($context, $groupname);
+        $this->render_help($element);
 
         $context->nextuniqueint = $innercontext->nextuniqueint;
     }

--- a/classes/form/elements/radio_group_element.php
+++ b/classes/form/elements/radio_group_element.php
@@ -19,6 +19,7 @@ namespace qtype_questionpy\form\elements;
 use qtype_questionpy\array_converter\array_converter;
 use qtype_questionpy\array_converter\converter_config;
 use qtype_questionpy\form\form_conditions;
+use qtype_questionpy\form\form_help;
 use qtype_questionpy\form\render_context;
 
 defined('MOODLE_INTERNAL') || die;
@@ -41,7 +42,7 @@ class radio_group_element extends form_element {
     /** @var bool */
     public bool $required = false;
 
-    use form_conditions;
+    use form_conditions, form_help;
 
     /**
      * Initializes the element.
@@ -75,7 +76,7 @@ class radio_group_element extends form_element {
             $radioarray[] = $context->mform->createElement("radio", $mangledname, null, $option->label, $option->value);
         }
 
-        $context->add_element("group", "radio_group_" . $this->name, $this->label, $radioarray, null, false);
+        $group = $context->add_element("group", "radio_group_" . $this->name, $this->label, $radioarray, null, false);
 
         if ($default) {
             $context->set_default($this->name, $default);
@@ -85,6 +86,7 @@ class radio_group_element extends form_element {
         }
 
         $this->render_conditions($context, $this->name);
+        $this->render_help($group);
     }
 }
 

--- a/classes/form/elements/select_element.php
+++ b/classes/form/elements/select_element.php
@@ -20,6 +20,7 @@ use HTML_QuickForm_select;
 use qtype_questionpy\array_converter\array_converter;
 use qtype_questionpy\array_converter\converter_config;
 use qtype_questionpy\form\form_conditions;
+use qtype_questionpy\form\form_help;
 use qtype_questionpy\form\render_context;
 
 defined('MOODLE_INTERNAL') || die;
@@ -44,7 +45,7 @@ class select_element extends form_element {
     /** @var bool */
     public bool $required = false;
 
-    use form_conditions;
+    use form_conditions, form_help;
 
     /**
      * Initializes the element.
@@ -91,6 +92,7 @@ class select_element extends form_element {
         }
 
         $this->render_conditions($context, $this->name);
+        $this->render_help($element);
     }
 }
 

--- a/classes/form/elements/static_text_element.php
+++ b/classes/form/elements/static_text_element.php
@@ -17,6 +17,7 @@
 namespace qtype_questionpy\form\elements;
 
 use qtype_questionpy\form\form_conditions;
+use qtype_questionpy\form\form_help;
 use qtype_questionpy\form\render_context;
 
 /**
@@ -35,7 +36,7 @@ class static_text_element extends form_element {
     /** @var string */
     public string $text;
 
-    use form_conditions;
+    use form_conditions, form_help;
 
     /**
      * Initializes the element.
@@ -56,8 +57,9 @@ class static_text_element extends form_element {
      * @param render_context $context target context
      */
     public function render_to(render_context $context): void {
-        $context->add_element("static", $this->name, $this->label, $this->text);
+        $element = $context->add_element("static", $this->name, $this->label, $this->text);
 
         $this->render_conditions($context, $this->name);
+        $this->render_help($element);
     }
 }

--- a/classes/form/elements/text_input_element.php
+++ b/classes/form/elements/text_input_element.php
@@ -17,6 +17,7 @@
 namespace qtype_questionpy\form\elements;
 
 use qtype_questionpy\form\form_conditions;
+use qtype_questionpy\form\form_help;
 use qtype_questionpy\form\render_context;
 
 /**
@@ -39,7 +40,7 @@ class text_input_element extends form_element {
     /** @var string|null */
     public ?string $placeholder = null;
 
-    use form_conditions;
+    use form_conditions, form_help;
 
     /**
      * Initializes the element.
@@ -72,7 +73,7 @@ class text_input_element extends form_element {
     public function render_to(render_context $context): void {
         $attributes = $this->placeholder ? ["placeholder" => $this->placeholder] : [];
 
-        $context->add_element("text", $this->name, $this->label, $attributes);
+        $element = $context->add_element("text", $this->name, $this->label, $attributes);
         $context->set_type($this->name, PARAM_TEXT);
 
         if ($this->default) {
@@ -83,5 +84,6 @@ class text_input_element extends form_element {
         }
 
         $this->render_conditions($context, $this->name);
+        $this->render_help($element);
     }
 }

--- a/classes/form/form_conditions.php
+++ b/classes/form/form_conditions.php
@@ -37,7 +37,7 @@ trait form_conditions {
     public array $hideif = [];
 
     /**
-     * Renders the conditions. To be called by the {@see renderable::render_to() render_to} of elements.
+     * Renders the conditions. To be called by the {@see qpy_renderable::render_to() render_to} of elements.
      *
      * @param render_context $context target context
      * @param string $name            name of this element

--- a/classes/form/form_help.php
+++ b/classes/form/form_help.php
@@ -1,0 +1,56 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\form;
+
+use HTML_QuickForm_element;
+
+/**
+ * Trait for elements that can have a help text hidden behind a button.
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+trait form_help {
+
+    /** @var string|null */
+    public ?string $help = null;
+
+    /**
+     * Renders the help button, if any. To be called by the {@see qpy_renderable::render_to() render_to} of elements.
+     *
+     * @param HTML_QuickForm_element $element target element
+     */
+    private function render_help(HTML_QuickForm_element $element): void {
+        global $OUTPUT;
+        if ($this->help) {
+            $element->_helpbutton = $OUTPUT->render(new dynamic_help_icon($this->help, $element->getLabel()));
+        }
+    }
+
+    /**
+     * Sets the given help text and returns this instance for chaining.
+     *
+     * @param string $text the new help text
+     * @return self $this
+     */
+    public function help(string $text): self {
+        $this->help = $text;
+        return $this;
+    }
+}

--- a/classes/form/form_section.php
+++ b/classes/form/form_section.php
@@ -30,7 +30,7 @@ defined('MOODLE_INTERNAL') || die;
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class form_section implements renderable {
+class form_section implements qpy_renderable {
 
     /** @var string */
     public string $name;

--- a/classes/form/qpy_form.php
+++ b/classes/form/qpy_form.php
@@ -30,7 +30,7 @@ defined('MOODLE_INTERNAL') || die;
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class qpy_form implements renderable {
+class qpy_form implements qpy_renderable {
     /** @var form_element[] elements to be appended to the default "General" section */
     public array $general;
     /** @var form_section[] additional custom sections */

--- a/classes/form/qpy_renderable.php
+++ b/classes/form/qpy_renderable.php
@@ -26,7 +26,7 @@ use qtype_questionpy\form\elements\form_element;
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-interface renderable {
+interface qpy_renderable {
     /**
      * Render this item to the given context.
      *

--- a/classes/form/render_context.php
+++ b/classes/form/render_context.php
@@ -25,7 +25,7 @@ use qtype_questionpy\utils;
  * Abstracts away the differences in rendering elements in a group and outside of a group.
  *
  * In a group, the element is created, and added as part of the group element. Outside of a group, the element is added
- * directly. This class abstracts away the differences so that {@see renderable::render_to} implementations needn't be
+ * directly. This class abstracts away the differences so that {@see qpy_renderable::render_to} implementations needn't be
  * aware of where they are being rendered. It does this while still allowing for checkbox controllers, which use an
  * entirely different method.
  *

--- a/edit_questionpy_form.php
+++ b/edit_questionpy_form.php
@@ -23,6 +23,7 @@
  */
 
 use qtype_questionpy\api\api;
+use qtype_questionpy\form\elements\text_input_element;
 use qtype_questionpy\form\root_render_context;
 use qtype_questionpy\localizer;
 use qtype_questionpy\utils;
@@ -134,7 +135,7 @@ class qtype_questionpy_edit_form extends question_edit_form {
 
         // Current form data was returned by the server along with the form definition in definition_inner.
         foreach (utils::flatten($this->currentdata, "qpy_form") as $name => $value) {
-            $this->question->{$name} = $value;
+            $question->{$name} = $value;
         }
 
         parent::set_data($question);

--- a/tests/data_provider.php
+++ b/tests/data_provider.php
@@ -25,6 +25,21 @@
 namespace qtype_questionpy;
 
 use qtype_questionpy\array_converter\array_converter;
+use qtype_questionpy\form\conditions\does_not_equal;
+use qtype_questionpy\form\conditions\equals;
+use qtype_questionpy\form\conditions\in;
+use qtype_questionpy\form\conditions\is_checked;
+use qtype_questionpy\form\conditions\is_not_checked;
+use qtype_questionpy\form\elements\checkbox_element;
+use qtype_questionpy\form\elements\checkbox_group_element;
+use qtype_questionpy\form\elements\group_element;
+use qtype_questionpy\form\elements\hidden_element;
+use qtype_questionpy\form\elements\option;
+use qtype_questionpy\form\elements\radio_group_element;
+use qtype_questionpy\form\elements\repetition_element;
+use qtype_questionpy\form\elements\select_element;
+use qtype_questionpy\form\elements\static_text_element;
+use qtype_questionpy\form\elements\text_input_element;
 
 /**
  * Data provider for {@see package}.
@@ -102,4 +117,45 @@ function package_provider2(): package {
             0 => 'fXuprCRqsLnQQYzFZgAt'
         ]
     ]);
+}
+
+/**
+ * Provides a number of elements for tests.
+ *
+ * @return array[] array of [element kind, element] pairs
+ */
+function element_provider(): array {
+    return [
+        ["checkbox", (new checkbox_element("my_checkbox", "Left", "Right", true, true))
+            ->disable_if(new is_checked("chk1"))
+            ->help("Help text")
+        ],
+        ["checkbox_group", new checkbox_group_element(
+            (new checkbox_element(
+                "my_checkbox", "Left", "Right",
+                true, true
+            ))->help("Help text")
+        )],
+        ["group", (new group_element("my_group", "Name", [
+            new text_input_element("first_name", "", true, null, "Vorname"),
+            new text_input_element("last_name", "", false, null, "Nachname (optional)"),
+        ]))
+            ->hide_if(new is_not_checked("chk1"))
+            ->help("Help text")
+        ],
+        ["hidden", (new hidden_element("my_hidden_value", "42"))->disable_if(new equals("input1", 7))],
+        ["radio_group", (new radio_group_element("my_radio", "Label", [
+            new option("Option 1", "opt1", true),
+            new option("Option 2", "opt2"),
+        ], true))->disable_if(new does_not_equal("input1", ""))],
+        ["repetition", new repetition_element("my_rep", 3, 2, null, [
+            new text_input_element("item", "Label"),
+        ])],
+        ["select", (new select_element("my_select", "Label", [
+            new option("Option 1", "opt1", true),
+            new option("Option 2", "opt2"),
+        ], true, true))->disable_if(new in("input1", ["valid", "also valid"]))],
+        ["static_text", new static_text_element("my_text", "Label", "Lorem ipsum dolor sit amet.")],
+        ["input", new text_input_element("my_field", "Label", true, "default", "placeholder")],
+    ];
 }

--- a/tests/form/elements/element_json_test.php
+++ b/tests/form/elements/element_json_test.php
@@ -16,12 +16,12 @@
 
 namespace qtype_questionpy\form\elements;
 
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . "/../../data_provider.php");
+
 use qtype_questionpy\array_converter\array_converter;
-use qtype_questionpy\form\conditions\does_not_equal;
-use qtype_questionpy\form\conditions\equals;
-use qtype_questionpy\form\conditions\in;
-use qtype_questionpy\form\conditions\is_checked;
-use qtype_questionpy\form\conditions\is_not_checked;
+use function qtype_questionpy\element_provider;
 
 /**
  * Tests of the (de)serialization of form elements.
@@ -35,13 +35,13 @@ class element_json_test extends \advanced_testcase {
     /**
      * Serializes values and compares resulting JSON to an expected file.
      *
-     * @param string $jsonfile path relative to `./json/` containing the JSON that should be parsed
-     * @param mixed $expected  the value expected after deserialization
+     * @param string $elementkind element kind, which the json file name is based on
+     * @param mixed $expected     the value expected after deserialization
      * @dataProvider deserialize_provider
      * @covers       \qtype_questionpy\form\elements
      */
-    public function test_deserialize(string $jsonfile, $expected): void {
-        $json = file_get_contents(__DIR__ . "/json/" . $jsonfile);
+    public function test_deserialize(string $elementkind, $expected): void {
+        $json = file_get_contents(__DIR__ . "/json/" . $elementkind . ".json");
 
         $array = json_decode($json, true);
         $actual = array_converter::from_array(form_element::class, $array);
@@ -52,16 +52,17 @@ class element_json_test extends \advanced_testcase {
     /**
      * Deserializes values from files and compares resulting object to an expected value.
      *
-     * @param string $expectedjsonfile path relative to `./json/` containing the JSON expected after serialization
-     * @param mixed $value             the value to serialize
+     * @param string $elementkind element kind, which the json file name is based on
+     * @param mixed $value        the value to serialize
      * @dataProvider serialize_provider
      * @covers       \qtype_questionpy\form\elements
      */
-    public function test_serialize(string $expectedjsonfile, $value): void {
+    public function test_serialize(string $elementkind, $value): void {
         $array = array_converter::to_array($value);
         $actualjson = json_encode($array);
+        $expectedjsonfilename = __DIR__ . "/json/" . $elementkind . ".json";
 
-        $this->assertJsonStringEqualsJsonFile(__DIR__ . "/json/" . $expectedjsonfile, $actualjson);
+        $this->assertJsonStringEqualsJsonFile($expectedjsonfilename, $actualjson);
     }
 
     /**
@@ -78,34 +79,6 @@ class element_json_test extends \advanced_testcase {
      * Provider of argument pairs for {@see test_serialize}.
      */
     public function serialize_provider(): array {
-        return [
-            ["checkbox.json", (new checkbox_element("my_checkbox", "Left", "Right", true, true))->disable_if(
-                new is_checked("chk1")
-            )],
-            ["checkbox_group.json", new checkbox_group_element(
-                new checkbox_element(
-                    "my_checkbox", "Left", "Right",
-                    true, true
-                )
-            )],
-            ["group.json", (new group_element("my_group", "Name", [
-                new text_input_element("first_name", "", true, null, "Vorname"),
-                new text_input_element("last_name", "", false, null, "Nachname (optional)"),
-            ]))->hide_if(new is_not_checked("chk1"))],
-            ["hidden.json", (new hidden_element("my_hidden_value", "42"))->disable_if(new equals("input1", 7))],
-            ["radio_group.json", (new radio_group_element("my_radio", "Label", [
-                new option("Option 1", "opt1", true),
-                new option("Option 2", "opt2"),
-            ], true))->disable_if(new does_not_equal("input1", ""))],
-            ["repetition.json", new repetition_element("my_rep", 3, 2, "", [
-                new text_input_element("item", ""),
-            ])],
-            ["select.json", (new select_element("my_select", "Label", [
-                new option("Option 1", "opt1", true),
-                new option("Option 2", "opt2"),
-            ], true, true))->disable_if(new in("input1", ["valid", "also valid"]))],
-            ["static_text.json", new static_text_element("my_text", "Label", "Lorem ipsum dolor sit amet.")],
-            ["input.json", new text_input_element("my_field", "Label", true, "default", "placeholder")],
-        ];
+        return element_provider();
     }
 }

--- a/tests/form/elements/html/checkbox.html
+++ b/tests/form/elements/html/checkbox.html
@@ -21,7 +21,9 @@
                     <div class="text-danger" title="Required">
                     <i class="icon fa fa-exclamation-circle text-danger fa-fw " title="Required" role="img" aria-label="Required"></i>
                     </div>
-                
+                <a class="btn btn-link p-0" role="button" data-container="body" data-toggle="popover" data-placement="right" data-content="Help text " data-html="true" tabindex="0" data-trigger="focus" aria-label="Help">
+  <i class="icon fa fa-question-circle text-info fa-fw " title="Help with Left" role="img" aria-label="Help with Left"></i>
+</a>
             </div>
         </div>
         <div class="form-control-feedback invalid-feedback" id="id_error_qpy_form_my_checkbox">

--- a/tests/form/elements/html/checkbox_group.html
+++ b/tests/form/elements/html/checkbox_group.html
@@ -22,7 +22,9 @@
                     <div class="text-danger" title="Required">
                     <i class="icon fa fa-exclamation-circle text-danger fa-fw " title="Required" role="img" aria-label="Required"></i>
                     </div>
-                
+                <a class="btn btn-link p-0" role="button" data-container="body" data-toggle="popover" data-placement="right" data-content="Help text " data-html="true" tabindex="0" data-trigger="focus" aria-label="Help">
+  <i class="icon fa fa-question-circle text-info fa-fw " title="Help with Left" role="img" aria-label="Help with Left"></i>
+</a>
             </div>
         </div>
         <div class="form-control-feedback invalid-feedback" id="id_error_qpy_form_my_checkbox">

--- a/tests/form/elements/html/group.html
+++ b/tests/form/elements/html/group.html
@@ -11,7 +11,9 @@
             </p>
 
         <div class="form-label-addon d-flex align-items-center align-self-start">
-            
+            <a class="btn btn-link p-0" role="button" data-container="body" data-toggle="popover" data-placement="right" data-content="Help text " data-html="true" tabindex="0" data-trigger="focus" aria-label="Help">
+  <i class="icon fa fa-question-circle text-info fa-fw " title="Help with Name" role="img" aria-label="Help with Name"></i>
+</a>
         </div>
     </div>
     <div class="col-md-9 form-inline align-items-start felement" data-fieldtype="group">

--- a/tests/form/elements/json/checkbox.json
+++ b/tests/form/elements/json/checkbox.json
@@ -11,5 +11,6 @@
       "name": "chk1"
     }
   ],
-  "hide_if": []
+  "hide_if": [],
+  "help": "Help text"
 }

--- a/tests/form/elements/json/checkbox_group.json
+++ b/tests/form/elements/json/checkbox_group.json
@@ -9,7 +9,8 @@
       "required": true,
       "selected": true,
       "disable_if": [],
-      "hide_if": []
+      "hide_if": [],
+      "help": "Help text"
     }
   ]
 }

--- a/tests/form/elements/json/group.json
+++ b/tests/form/elements/json/group.json
@@ -11,7 +11,8 @@
       "default": null,
       "placeholder": "Vorname",
       "disable_if": [],
-      "hide_if": []
+      "hide_if": [],
+      "help": null
     },
     {
       "kind": "input",
@@ -21,7 +22,8 @@
       "default": null,
       "placeholder": "Nachname (optional)",
       "disable_if": [],
-      "hide_if": []
+      "hide_if": [],
+      "help": null
     }
   ],
   "disable_if": [],
@@ -30,5 +32,6 @@
       "kind": "is_not_checked",
       "name": "chk1"
     }
-  ]
+  ],
+  "help": "Help text"
 }

--- a/tests/form/elements/json/input.json
+++ b/tests/form/elements/json/input.json
@@ -6,5 +6,6 @@
   "placeholder": "placeholder",
   "required": true,
   "disable_if": [],
-  "hide_if": []
+  "hide_if": [],
+  "help": null
 }

--- a/tests/form/elements/json/radio_group.json
+++ b/tests/form/elements/json/radio_group.json
@@ -22,5 +22,6 @@
       "value": ""
     }
   ],
-  "hide_if": []
+  "hide_if": [],
+  "help": null
 }

--- a/tests/form/elements/json/repetition.json
+++ b/tests/form/elements/json/repetition.json
@@ -3,17 +3,18 @@
   "name": "my_rep",
   "initial_elements": 3,
   "increment": 2,
-  "button_label": "",
+  "button_label": null,
   "elements": [
     {
       "kind": "input",
       "name": "item",
-      "label": "",
+      "label": "Label",
       "placeholder": null,
       "required": false,
       "default": null,
       "disable_if": [],
-      "hide_if": []
+      "hide_if": [],
+      "help": null
     }
   ]
 }

--- a/tests/form/elements/json/select.json
+++ b/tests/form/elements/json/select.json
@@ -26,5 +26,6 @@
       ]
     }
   ],
-  "hide_if": []
+  "hide_if": [],
+  "help": null
 }

--- a/tests/form/elements/json/static_text.json
+++ b/tests/form/elements/json/static_text.json
@@ -4,5 +4,6 @@
   "label": "Label",
   "text": "Lorem ipsum dolor sit amet.",
   "disable_if": [],
-  "hide_if": []
+  "hide_if": [],
+  "help": null
 }

--- a/tests/form/elements/test_moodleform.php
+++ b/tests/form/elements/test_moodleform.php
@@ -21,7 +21,7 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 require_once($CFG->libdir . "/formslib.php");
 
-use qtype_questionpy\form\renderable;
+use qtype_questionpy\form\qpy_renderable;
 use qtype_questionpy\form\root_render_context;
 
 /**
@@ -34,16 +34,16 @@ use qtype_questionpy\form\root_render_context;
  */
 class test_moodleform extends \moodleform {
     /**
-     * @var renderable element to render
+     * @var qpy_renderable element to render
      */
-    private renderable $element;
+    private qpy_renderable $element;
 
     /**
      * Initializes a new {@see test_moodleform}.
      *
-     * @param renderable $element element to render
+     * @param qpy_renderable $element element to render
      */
-    public function __construct(renderable $element) {
+    public function __construct(qpy_renderable $element) {
         $this->element = $element;
         parent::__construct(null, null, "post", "", ["id" => "my_form"]);
     }

--- a/tests/package_test.php
+++ b/tests/package_test.php
@@ -20,8 +20,8 @@ use moodle_exception;
 use qtype_questionpy\array_converter\array_converter;
 
 defined('MOODLE_INTERNAL') || die;
-require(__DIR__ . '/data_provider.php');
 
+require_once(__DIR__ . '/data_provider.php');
 
 /**
  * Unit tests for the questionpy question type class.
@@ -199,7 +199,6 @@ class package_test extends \advanced_testcase {
         } catch (\Exception $e) {
             return;
         }
-
     }
 
     /**
@@ -218,7 +217,6 @@ class package_test extends \advanced_testcase {
         $this->assertEmpty($difference);
         $this->assertTrue($package1->equals($package2));
     }
-
 
     /**
      * Stores two packages in the DB.


### PR DESCRIPTION
Siehe <https://github.com/questionpy-org/questionpy-sdk/issues/28>

Das eingebaute `help_icon` und die darauf basierende Methode `addHelpIcon` verwenden immer `get_string`. Deshalb musste ich `help_icon` weitestgehend kopieren. Die neue Klasse `dynamic_help_icon` verwendet allerdings die selbe Mustache-Template.

Ich habe mich dagegen entschieden, den Alt-Text des Buttons (der beim Hovern darüber angezeigt wird) vom Paket angeben zu lassen. Für Elemente mit Label wird `Help with {$element->getLabel()}` verwendet, andernfalls `Help with this`. Das scheint so Konvention in Moodle zu sein und ich sehe nicht wirklich einen Use-Case, davon groß abzuweichen.

Dass der Workflow gerade fehlschlägt liegt an false positives in Moodlecheck, die mit <https://github.com/moodlehq/moodle-local_moodlecheck/pull/109> beseitigt werden.