### PR TITLE
#39: Schönere Repetitions mit Entfernen-Knopf

### DIFF
--- a/classes/form/elements/repetition_element.php
+++ b/classes/form/elements/repetition_element.php
@@ -37,9 +37,9 @@ class repetition_element extends form_element {
     /** @var string */
     public string $name;
     /** @var int number of repetitions to show initially */
-    public int $initialelements;
+    public int $initialrepetitions;
     /** @var int minimum number of repetitions, which cannot be removed */
-    public int $minimumelements = 1;
+    public int $minimumrepetitions = 1;
     /** @var int number of elements to add with each click of the button */
     public int $increment;
     /** @var string|null label for the button which adds additional blanks, null to use default */
@@ -52,15 +52,15 @@ class repetition_element extends form_element {
      * Initializes the element.
      *
      * @param string $name
-     * @param int $initialelements     number of elements to show initially
-     * @param int $increment           number of elements to add with each click of the button
+     * @param int $initialrepetitions  number of repetitions to show initially
+     * @param int $increment           number of repetitions to add with each click of the button
      * @param string|null $buttonlabel label for the button which adds additional blanks, null to use default
      * @param form_element[] $elements
      */
-    public function __construct(string $name, int $initialelements, int $increment, ?string $buttonlabel,
+    public function __construct(string $name, int $initialrepetitions, int $increment, ?string $buttonlabel,
                                 array  $elements) {
         $this->name = $name;
-        $this->initialelements = $initialelements;
+        $this->initialrepetitions = $initialrepetitions;
         $this->increment = $increment;
         $this->buttonlabel = $buttonlabel;
         $this->elements = $elements;
@@ -87,7 +87,7 @@ class repetition_element extends form_element {
             $repeatsname,
             isset($context->data[$this->name])
                 ? count($context->data[$this->name])
-                : max($this->initialelements, $this->minimumelements),
+                : max($this->initialrepetitions, $this->minimumrepetitions),
             PARAM_INT
         );
 
@@ -117,7 +117,7 @@ class repetition_element extends form_element {
             }
         }
 
-        $allowremoval = $repeats - count($removed) > $this->minimumelements;
+        $allowremoval = $repeats - count($removed) > $this->minimumrepetitions;
 
         $removestring = get_string("remove");
         global $OUTPUT;
@@ -152,8 +152,8 @@ class repetition_element extends form_element {
 
 array_converter::configure(repetition_element::class, function (converter_config $config) {
     $config
-        ->rename("initialelements", "initial_elements")
-        ->rename("minimumelements", "minimum_elements")
+        ->rename("initialrepetitions", "initial_repetitions")
+        ->rename("minimumrepetitions", "minimum_repetitions")
         ->rename("buttonlabel", "button_label")
         ->array_elements("elements", form_element::class);
 });

--- a/classes/question_service.php
+++ b/classes/question_service.php
@@ -97,6 +97,10 @@ class question_service {
             "questionid" => $question->id,
         ]);
 
+        // Repetition_elements may produce numeric arrays with gaps. We want them to become JSON arrays, so we reindex.
+        // Form element names may not begin with a digit, so this wont accidentally change them.
+        utils::reindex_integer_arrays($question->qpy_form);
+
         $response = $this->api->create_question(
             $question->qpy_package_hash,
             $existingrecord ? $existingrecord->state : null,

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -17,6 +17,7 @@
 namespace qtype_questionpy;
 
 use Generator;
+use qtype_questionpy\form\elements\repetition_element;
 
 /**
  * Utility functions used in multiple places.
@@ -77,5 +78,31 @@ class utils {
         }
 
         return $current;
+    }
+
+    /**
+     * Within `$array`, recursively looks for any arrays with numeric-only keys with gaps and reindexes them.
+     *
+     * This causes {@see json_encode} to serialize these arrays (with gaps) to JSON objects rather than JSON
+     * arrays. {@see repetition_element}s produce numeric arrays with gaps when repetitions are removed.
+     *
+     * @param array $array
+     * @return void
+     */
+    public static function reindex_integer_arrays(array &$array): void {
+        $numeric = true;
+        foreach ($array as $key => &$value) {
+            if (!is_integer($key)) {
+                $numeric = false;
+            }
+
+            if (is_array($value)) {
+                self::reindex_integer_arrays($value);
+            }
+        }
+
+        if ($numeric) {
+            $array = array_values($array);
+        }
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -46,3 +46,30 @@
 #fgroup_id_questionpy_package_container input:checked + .card {
     border-color: var(--primary);
 }
+
+.qpy-repetition {
+    /* Visually groups the elements of each repetition. */
+    background: #eee;
+    border: 1px solid #bbb;
+
+    margin-bottom: 1em;
+
+    display: flex;
+    flex-direction: row;
+}
+
+.qpy-repetition-content {
+    padding-top: 1em;
+    flex-grow: 1;
+}
+
+.qpy-repetition-controls {
+    flex-grow: 0;
+
+    display: flex;
+    flex-direction: column;
+}
+
+.qpy-repetition-remove {
+    margin: .5em;
+}

--- a/tests/form/elements/html/repetition.html
+++ b/tests/form/elements/html/repetition.html
@@ -5,7 +5,7 @@
 <input name="_qf__qtype_questionpy_form_elements_test_moodleform" type="hidden" value="1">
 </div>
 
-<div id="fitem_id_qpy_form_my_rep_0_item" class="form-group row  fitem   ">
+<div class="qpy-repetition"><div class="qpy-repetition-content"><div id="fitem_id_qpy_form_my_rep_0_item" class="form-group row  fitem   ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
                 <label id="id_qpy_form_my_rep_0_item_label" class="d-inline word-break " for="id_qpy_form_my_rep_0_item">
@@ -22,7 +22,7 @@
             
         </div>
     </div>
-</div><div id="fitem_id_qpy_form_my_rep_1_item" class="form-group row  fitem   ">
+</div></div><div class="qpy-repetition-controls"><button name="qpy_repeat_remove_my_rep[0]" type="submit" class="btn btn-secondary qpy-repetition-remove" value="remove"><i class="icon fa fa-trash fa-fw " title="Remove" role="img" aria-label="Remove"></i> Remove</button></div></div><div class="qpy-repetition"><div class="qpy-repetition-content"><div id="fitem_id_qpy_form_my_rep_1_item" class="form-group row  fitem   ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
                 <label id="id_qpy_form_my_rep_1_item_label" class="d-inline word-break " for="id_qpy_form_my_rep_1_item">
@@ -39,7 +39,7 @@
             
         </div>
     </div>
-</div><div id="fitem_id_qpy_form_my_rep_2_item" class="form-group row  fitem   ">
+</div></div><div class="qpy-repetition-controls"><button name="qpy_repeat_remove_my_rep[1]" type="submit" class="btn btn-secondary qpy-repetition-remove" value="remove"><i class="icon fa fa-trash fa-fw " title="Remove" role="img" aria-label="Remove"></i> Remove</button></div></div><div class="qpy-repetition"><div class="qpy-repetition-content"><div id="fitem_id_qpy_form_my_rep_2_item" class="form-group row  fitem   ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
                 <label id="id_qpy_form_my_rep_2_item_label" class="d-inline word-break " for="id_qpy_form_my_rep_2_item">
@@ -56,7 +56,7 @@
             
         </div>
     </div>
-</div><div id="fitem_id_qpy_repeat_add_more_my_rep" class="form-group row  fitem femptylabel  ">
+</div></div><div class="qpy-repetition-controls"><button name="qpy_repeat_remove_my_rep[2]" type="submit" class="btn btn-secondary qpy-repetition-remove" value="remove"><i class="icon fa fa-trash fa-fw " title="Remove" role="img" aria-label="Remove"></i> Remove</button></div></div><div id="fitem_id_qpy_repeat_add_more_my_rep" class="form-group row  fitem femptylabel  ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
         <div class="form-label-addon d-flex align-items-center align-self-start">

--- a/tests/form/elements/json/repetition.json
+++ b/tests/form/elements/json/repetition.json
@@ -2,6 +2,7 @@
   "kind": "repetition",
   "name": "my_rep",
   "initial_elements": 3,
+  "minimum_elements": 1,
   "increment": 2,
   "button_label": null,
   "elements": [

--- a/tests/form/elements/json/repetition.json
+++ b/tests/form/elements/json/repetition.json
@@ -1,8 +1,8 @@
 {
   "kind": "repetition",
   "name": "my_rep",
-  "initial_elements": 3,
-  "minimum_elements": 1,
+  "initial_repetitions": 3,
+  "minimum_repetitions": 1,
   "increment": 2,
   "button_label": null,
   "elements": [


### PR DESCRIPTION
The visual grouping is taken from per-answer fields in Moodle question types.

In contrast to Moodle's repeat_elements, the remove-button is automatically added and separate from the repetition content.

Das Ganze sieht dann so aus:
![grafik](https://github.com/questionpy-org/moodle-qtype_questionpy/assets/29020266/2fcb1832-7d94-4b0b-8838-3987e33b4bb2)

Closes #39