### PR TITLE
feat: add package version entries

### DIFF
--- a/classes/package.php
+++ b/classes/package.php
@@ -244,7 +244,7 @@ class package {
             }
 
             if ($this->tags) {
-                // Store each tag with the package hash in the tag table.
+                // Store each tag with the package id in the tag table.
                 $tagsdata = [];
                 foreach ($this->tags as $tag) {
                     $tagsdata[] = [
@@ -266,6 +266,7 @@ class package {
             }
         }
         // Add the package version.
+        // TODO: Update the package data in qtype_questionpy_package if the version is newer than the existing ones.
         $pkgversionid = $DB->insert_record('qtype_questionpy_pkgversion', [
             'packageid' => $packageid,
             'contextid' => $contextid,
@@ -325,7 +326,7 @@ class package {
     }
 
     /**
-     * Get packages from the db matching given conditions. Note: only conditions stored in the package table
+     * Get packages from the db matching given conditions. Note: only conditions stored in the package version table
      * are applicable.
      *
      * @param array|null $conditions
@@ -349,10 +350,10 @@ class package {
      * Get package related data like name, description and tags.
      *
      * @param string $packageid
-     * @return mixed|\stdClass
+     * @return object
      * @throws moodle_exception
      */
-    private static function get_package_data(string $packageid) {
+    private static function get_package_data(string $packageid): object {
         global $DB;
         $package = $DB->get_record('qtype_questionpy_package', ['id' => $packageid]);
 
@@ -373,7 +374,7 @@ class package {
      * @return array
      * @throws dml_exception
      */
-    private static function get_languagedata(int $packageid) {
+    private static function get_languagedata(int $packageid): array {
         global $DB;
         $languagedata = $DB->get_records('qtype_questionpy_language', ['packageid' => $packageid]);
         $language = [];
@@ -394,7 +395,7 @@ class package {
      * @return array
      * @throws dml_exception
      */
-    private static function get_tagdata(int $packageid) {
+    private static function get_tagdata(int $packageid): array {
         global $DB;
         $tagdata = $DB->get_records('qtype_questionpy_tags', ['packageid' => $packageid]);
         $tags = [];

--- a/classes/question_service.php
+++ b/classes/question_service.php
@@ -62,8 +62,8 @@ class question_service {
             $package = package::get_records(["id" => $record->pkgversionid])[0] ?? null;
             if (!$package) {
                 throw new \coding_exception(
-                    "No package record with ID '{$record->pkgversionid}' was found despite being referenced by" .
-                    " question {$questionid}"
+                    "No package version record with ID '{$record->pkgversionid}' was found despite being referenced" .
+                    " by question {$questionid}"
                 );
             }
 

--- a/classes/question_service.php
+++ b/classes/question_service.php
@@ -59,10 +59,10 @@ class question_service {
         $result = new stdClass();
         $record = $DB->get_record(self::QUESTION_TABLE, ["questionid" => $questionid]);
         if ($record) {
-            $package = package::get_records(["id" => $record->packageid])[0] ?? null;
+            $package = package::get_records(["id" => $record->pkgversionid])[0] ?? null;
             if (!$package) {
                 throw new \coding_exception(
-                    "No package record with ID '{$record->packageid}' was found despite being referenced by" .
+                    "No package record with ID '{$record->pkgversionid}' was found despite being referenced by" .
                     " question {$questionid}"
                 );
             }
@@ -85,8 +85,8 @@ class question_service {
     public function upsert_question(object $question): void {
         global $DB;
 
-        [$packageid] = $this->get_package($question->qpy_package_hash);
-        if (!$packageid) {
+        [$pkgversionid] = $this->get_package($question->qpy_package_hash);
+        if (!$pkgversionid) {
             throw new moodle_exception(
                 "package_not_found", "qtype_questionpy", "",
                 (object)["packagehash" => $question->qpy_package_hash]
@@ -110,8 +110,8 @@ class question_service {
             if ($existingrecord->state !== $response->state) {
                 $update["state"] = $response->state;
             }
-            if ($packageid !== $existingrecord->packageid) {
-                $update["packageid"] = $packageid;
+            if ($pkgversionid !== $existingrecord->pkgversionid) {
+                $update["pkgversionid"] = $pkgversionid;
             }
 
             if (count($update) > 1) {
@@ -122,7 +122,7 @@ class question_service {
             $DB->insert_record(self::QUESTION_TABLE, [
                 "questionid" => $question->id,
                 "feedback" => "",
-                "packageid" => $packageid,
+                "pkgversionid" => $pkgversionid,
                 "state" => $response->state,
             ]);
         }

--- a/db/install.xml
+++ b/db/install.xml
@@ -26,33 +26,51 @@
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="questionid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Foreign key references question.id" />
         <FIELD NAME="feedback" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Feedback shown for any response."/>
-        <FIELD NAME="packageid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="pkgversionid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="state" TYPE="text" NOTNULL="true" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id" />
         <KEY NAME="questionid" TYPE="foreign-unique" FIELDS="questionid" REFTABLE="question" REFFIELDS="id" />
-        <KEY NAME="packageid" TYPE="foreign" FIELDS="packageid" REFTABLE="qtype_questionpy_package" REFFIELDS="id"/>
+        <KEY NAME="pkgversionid" TYPE="foreign" FIELDS="pkgversionid" REFTABLE="qtype_questionpy_pkgversion" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
+
     <TABLE NAME="qtype_questionpy_package" COMMENT="Available QuestionPy Packages on the Moodle Server">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="contextid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="hash" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="shortname" TYPE="char" LENGTH="127" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="namespace" TYPE="char" LENGTH="127" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="version" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="type" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="author" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="url" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="icon" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="URL to the icon"/>
         <FIELD NAME="license" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
     </TABLE>
+
+    <TABLE NAME="qtype_questionpy_pkgversion" COMMENT="Available QuestionPy Package Versions on the Moodle Server">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="packageid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="contextid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="hash" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="version" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="packageid" TYPE="foreign" FIELDS="packageid" REFTABLE="qtype_questionpy_package" REFFIELDS="id"/>
+        <KEY NAME="userid" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id"/>
+      </KEYS>
+    </TABLE>
+
     <TABLE NAME="qtype_questionpy_language" COMMENT="Table storing localized package data.">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
@@ -66,6 +84,7 @@
         <KEY NAME="packageid" TYPE="foreign" FIELDS="packageid" REFTABLE="qtype_questionpy_package" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
+
     <TABLE NAME="qtype_questionpy_tags" COMMENT="Table storing package tags.">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
@@ -77,5 +96,19 @@
         <KEY NAME="packageid" TYPE="foreign" FIELDS="packageid" REFTABLE="qtype_questionpy_package" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
+
+    <TABLE NAME="qtype_questionpy_lastused" COMMENT="Table storing last used packages in a specific context.">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="contextid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="packageid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="timeused" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="packageid" TYPE="foreign" FIELDS="packageid" REFTABLE="qtype_questionpy_package" REFFIELDS="id"/>
+      </KEYS>
+    </TABLE>
+
   </TABLES>
 </XMLDB>

--- a/tests/data_provider.php
+++ b/tests/data_provider.php
@@ -41,82 +41,47 @@ use qtype_questionpy\form\elements\select_element;
 use qtype_questionpy\form\elements\static_text_element;
 use qtype_questionpy\form\elements\text_input_element;
 
+
 /**
- * Data provider for {@see package}.
+ * Returns a package object which can be modified by an array of attributes.
  *
- * @return package A sample package for the tests
+ * @param array $attributes
+ * @return package
+ * @throws \moodle_exception
  */
-function package_provider1(): package {
-    return array_converter::from_array(package::class, [
-        'package_hash' => 'dkZZGAOgHTpBOSZMBGNM',
-        'short_name' => 'adAqMNxOZNhuSUWflNui',
-        'namespace' => 'default',
+function package_provider(array $attributes = []): package {
+    $data = array_merge([
+        'short_name' => 'my_short_name',
+        'namespace' => 'my_namespace',
         'name' => [
-            'en' => 'She piece local.',
-            'de' => 'Style important.'
+            'en' => 'de: My Name',
+            'de' => 'en: My Name'
         ],
-        'version' => '865.7797993.0--.0',
+        'version' => '0.1.0',
         'type' => 'questiontype',
-        'author' => 'Mario Hunt',
-        'url' => 'http://www.kane.com/',
+        'author' => 'John Doe',
+        'url' => 'http://www.example.com/',
         'languages' => [
             0 => 'en',
             1 => 'de'
         ],
         'description' => [
-            'en' => 'en: Activity organization letter. Report alone why center.
-                    Real outside glass maintain right hear.
-                    Brother develop process work. Build ago north.
-                    Develop with defense understand garden recently work.',
-            'de' => 'de: Activity few enter medical side position. Safe need no guy price.
-                    Source necessary our me series month seven born.
-                    Anyone everything interest where accept apply. Expert great significant.'
+            'en' => 'en: Lorem ipsum dolor sit amet.',
+            'de' => 'de: Lorem ipsum dolor sit amet.'
         ],
         'icon' => 'https://placehold.jp/40e47e/598311/150x150.png',
-        'license' => '',
+        'license' => 'MIT',
         'tags' => [
-            0 => 'fXuprCRqsLnQQYzFZgAt'
-        ]
-    ]);
-}
+            0 => 'my_tag_0',
+            1 => 'my_tag_1',
+            2 => 'my_tag_2'
+        ]], $attributes);
 
-/**
- * Data provider for {@see package}.
- *
- * @return package Same package as {@see package_provider1} but values in languages array are swapped.
- */
-function package_provider2(): package {
-    return array_converter::from_array(package::class, [
-        'package_hash' => 'dkZZGAOgHTpBOSZMBGNM',
-        'short_name' => 'adAqMNxOZNhuSUWflNui',
-        'namespace' => 'default',
-        'name' => [
-            'en' => 'She piece local.',
-            'de' => 'Style important.'
-        ],
-        'version' => '865.7797993.0--.0',
-        'type' => 'questiontype',
-        'author' => 'Mario Hunt',
-        'url' => 'http://www.kane.com/',
-        'languages' => [
-            0 => 'de',
-            1 => 'en'
-        ],
-        'description' => [
-            'en' => 'en: Activity organization letter. Report alone why center.
-                    Real outside glass maintain right hear.
-                    Brother develop process work. Build ago north.
-                    Develop with defense understand garden recently work.',
-            'de' => 'de: Activity few enter medical side position. Safe need no guy price.
-                    Source necessary our me series month seven born.
-                    Anyone everything interest where accept apply. Expert great significant.'
-        ],
-        'icon' => 'https://placehold.jp/40e47e/598311/150x150.png',
-        'license' => '',
-        'tags' => [
-            0 => 'fXuprCRqsLnQQYzFZgAt'
-        ]
-    ]);
+    if (!isset($attributes['package_hash'])) {
+        $data['package_hash'] = hash('sha256', $data['short_name'] . $data['namespace'] . $data['version']);
+    }
+
+    return array_converter::from_array(package::class, $data);
 }
 
 /**

--- a/tests/package_test.php
+++ b/tests/package_test.php
@@ -220,10 +220,10 @@ class package_test extends \advanced_testcase {
         $user = $this->getDataGenerator()->create_user();
         $this->setUser($user);
 
+        $timestamp = time();
+
         $package = array_converter::from_array(package::class, $packagedata);
         $package->store_in_db();
-
-        $timestamp = time();
 
         // Check qtype_questionpy_pkgversion table.
         $this->assertEquals(1, $DB->count_records('qtype_questionpy_pkgversion'));

--- a/tests/package_test.php
+++ b/tests/package_test.php
@@ -33,48 +33,108 @@ require_once(__DIR__ . '/data_provider.php');
 class package_test extends \advanced_testcase {
 
     /**
-     * Tests the function get_package.
+     * Provides valid package data.
+     *
+     * @return array
+     */
+    public function valid_package_data_provider(): array {
+        return [
+            'Minimal package data' => [[
+                'package_hash' => 'hash',
+                'short_name' => 'shortname',
+                'namespace' => 'namespace',
+                'name' => [],
+                'version' => '1.0.0',
+                'type' => 'question',
+            ]],
+            'Maximal package data' => [[
+                'package_hash' => 'hash',
+                'short_name' => 'shortname',
+                'namespace' => 'namespace',
+                'name' => [],
+                'version' => '1.0.0',
+                'type' => 'question',
+
+                'author' => 'author',
+                'url' => 'url',
+                'languages' => [],
+                'description' => [],
+                'icon' => 'icon',
+                'license' => 'license',
+                'tags' => []
+            ]],
+            'With tags' => [[
+                'package_hash' => 'hash',
+                'short_name' => 'shortname',
+                'namespace' => 'namespace',
+                'name' => [],
+                'version' => '1.0.0',
+                'type' => 'question',
+                'tags' => ['tag1', 'tag2']
+            ]],
+            'With one language' => [[
+                'package_hash' => 'hash',
+                'short_name' => 'shortname',
+                'namespace' => 'namespace',
+                'name' => ['en' => 'en_name'],
+                'version' => '1.0.0',
+                'type' => 'question',
+                'languages' => ['en'],
+                'description' => ['en' => 'en_description']
+            ]],
+            'With multiple languages' => [[
+                'package_hash' => 'hash',
+                'short_name' => 'shortname',
+                'namespace' => 'namespace',
+                'name' => ['en' => 'en_name', 'de' => 'de_name', 'fr' => 'fr_name'],
+                'version' => '1.0.0',
+                'type' => 'question',
+                'languages' => ['en', 'de', 'fr'],
+                'description' => ['en' => 'en_description', 'de' => 'de_description', 'fr' => 'fr_description']
+            ]],
+            'With multiple languages and tags' => [[
+                'package_hash' => 'hash',
+                'short_name' => 'shortname',
+                'namespace' => 'namespace',
+                'name' => ['en' => 'en_name', 'de' => 'de_name', 'fr' => 'fr_name'],
+                'version' => '1.0.0',
+                'type' => 'question',
+                'languages' => ['en', 'de', 'fr'],
+                'description' => ['en' => 'en_description', 'de' => 'de_description', 'fr' => 'fr_description'],
+                'tags' => ['tag1', 'tag2']
+            ]],
+
+        ];
+    }
+
+    /**
+     * Tests the method get_package valid input.
+     *
+     * @dataProvider valid_package_data_provider
+     * @covers       \package::from_array
+     * @param array $packagedata
+     * @return void
+     * @throws moodle_exception
+     */
+    public function test_from_array($packagedata): void {
+        array_converter::from_array(package::class, $packagedata);
+    }
+
+    /**
+     * Tests the method get_package with faulty input.
      *
      * @covers \package::from_array
      * @return void
      * @throws moodle_exception
      */
-    public function test_from_array(): void {
-        $minimum = [
-            'package_hash' => 'hash',
-            'short_name' => 'shortname',
-            'namespace' => 'namespace',
-            'name' => [],
-            'version' => '1.0.0',
-            'type' => 'question',
-        ];
-        array_converter::from_array(package::class, $minimum);
-
-        $maximum = [
-            'package_hash' => 'hash',
-            'short_name' => 'shortname',
-            'namespace' => 'namespace',
-            'name' => [],
-            'version' => '1.0.0',
-            'type' => 'question',
-
-            'author' => 42,
-            'url' => 'url',
-            'languages' => [],
-            'description' => [],
-            'icon' => 'icon',
-            'license' => 'license',
-            'tags' => []
-        ];
-        array_converter::from_array(package::class, $maximum);
-
+    public function test_faulty_from_array() {
         $this->expectException(moodle_exception::class);
         $faulty = ['faulty' => 'hash'];
         array_converter::from_array(package::class, $faulty);
     }
 
     /**
-     * Tests the function get_localized_name.
+     * Tests the method get_localized_name.
      *
      * @covers \package::get_localized_name
      * @return void
@@ -102,7 +162,7 @@ class package_test extends \advanced_testcase {
     }
 
     /**
-     * Tests the function get_localized_description.
+     * Tests the method get_localized_description.
      *
      * @covers \package::get_localized_description
      * @return void
@@ -144,39 +204,179 @@ class package_test extends \advanced_testcase {
     }
 
     /**
-     * Test if after adding a package to the db, there is indeed one more record present.
+     * Tests the method store_in_db.
      *
-     * @covers \qtype_questionpy\package::store_in_db
+     * @covers \package::store_in_db
+     * @dataProvider valid_package_data_provider
+     * @param array $packagedata
      * @return void
-     * @throws \dml_exception
-     * @throws \moodle_exception
+     * @throws moodle_exception
      */
-    public function test_storing_one_package_in_db() {
-        global $DB;
-        $this->resetAfterTest(true);
+    public function test_store_package_in_db($packagedata) {
+        global $DB, $USER;
+        $this->resetAfterTest();
 
-        $package = package_provider1();
-        $initial = count($DB->get_records('qtype_questionpy_package'));
+        // Create and set example user.
+        $user = $this->getDataGenerator()->create_user();
+        $this->setUser($user);
 
+        $package = array_converter::from_array(package::class, $packagedata);
         $package->store_in_db();
-        $final = count($DB->get_records('qtype_questionpy_package'));
 
-        $this->assertEquals(1, $final - $initial);
+        $timestamp = time();
+
+        // Check qtype_questionpy_pkgversion table.
+        $this->assertEquals(1, $DB->count_records('qtype_questionpy_pkgversion'));
+        $record = $DB->get_record('qtype_questionpy_pkgversion', ['hash' => $packagedata['package_hash']]);
+        $this->assertNotFalse($record);
+        $this->assertEquals($packagedata['version'], $record->version);
+        $this->assertGreaterThanOrEqual($timestamp, $record->timecreated);
+        $this->assertEquals($USER->id, $record->userid);
+
+        $packageid = $record->packageid;
+
+        // Check qtype_questionpy_package table.
+        $this->assertEquals(1, $DB->count_records('qtype_questionpy_package'));
+        $record = $DB->get_record('qtype_questionpy_package', ['id' => $packageid]);
+        $this->assertNotFalse($record);
+        $this->assertEquals($packagedata['short_name'], $record->shortname);
+        $this->assertEquals($packagedata['namespace'], $record->namespace);
+        $this->assertEquals($packagedata['type'], $record->type);
+        $this->assertEquals($packagedata['author'] ?? null, $record->author);
+        $this->assertEquals($packagedata['url'] ?? null, $record->url);
+        $this->assertEquals($packagedata['icon'] ?? null, $record->icon);
+        $this->assertEquals($packagedata['license'] ?? null, $record->license);
+        $this->assertGreaterThanOrEqual($timestamp, $record->timemodified);
+        $this->assertGreaterThanOrEqual($timestamp, $record->timecreated);
+
+        // Check qtype_questionpy_language table.
+        $languages = $packagedata['languages'] ?? [];
+        $this->assertEquals(count($languages), $DB->count_records('qtype_questionpy_language'));
+        foreach ($languages as $language) {
+            $record = $DB->get_record('qtype_questionpy_language', ['packageid' => $packageid, 'language' => $language]);
+            $this->assertNotFalse($record);
+            $this->assertEquals($packagedata['name'][$language], $record->name);
+            $this->assertEquals($packagedata['description'][$language], $record->description);
+        }
+
+        // Check qtype_questionpy_tags table.
+        $tags = $packagedata['tags'] ?? [];
+        $this->assertEquals(count($tags), $DB->count_records('qtype_questionpy_tags'));
+        foreach ($tags as $tag) {
+            $record = $DB->get_record('qtype_questionpy_tags', ['packageid' => $packageid, 'tag' => $tag]);
+            $this->assertNotFalse($record);
+        }
     }
 
     /**
-     * Adds one Package to db, then retrieves it. Tests if the retrieved package is the same as the original.
+     * Tests the method store_in_db when it's called multiple times on the same package.
+     *
+     * @covers \package::store_in_db
+     * @return void
+     * @throws moodle_exception
+     */
+    public function test_store_package_twice_in_db() {
+        global $DB;
+        $this->resetAfterTest();
+
+        $package = package_provider(['languages' => ['en', 'de'], 'tags' => ['tag_0', 'tag_1']]);
+        $package->store_in_db();
+        $package->store_in_db();
+
+        $this->assertEquals(1, $DB->count_records('qtype_questionpy_pkgversion'));
+        $this->assertEquals(1, $DB->count_records('qtype_questionpy_package'));
+        $this->assertEquals(2, $DB->count_records('qtype_questionpy_language'));
+        $this->assertEquals(2, $DB->count_records('qtype_questionpy_tags'));
+    }
+
+    /**
+     * Tests the method store_in_db with multiple versions of the same package.
+     *
+     * @covers \package::store_in_db
+     * @return void
+     * @throws moodle_exception
+     */
+    public function test_store_different_versions_of_package_in_db() {
+        global $DB;
+        $this->resetAfterTest();
+
+        $package1 = package_provider(['version' => '1.0.0', 'languages' => ['en'], 'tags' => ['tag_0']]);
+        $package2 = package_provider(['version' => '2.0.0', 'languages' => ['en'], 'tags' => ['tag_0']]);
+
+        $package1->store_in_db();
+        $package2->store_in_db();
+
+        $this->assertEquals(2, $DB->count_records('qtype_questionpy_pkgversion'));
+        $this->assertEquals(1, $DB->count_records('qtype_questionpy_package'));
+        $this->assertEquals(1, $DB->count_records('qtype_questionpy_language'));
+        $this->assertEquals(1, $DB->count_records('qtype_questionpy_tags'));
+    }
+
+    /**
+     * Tests the method delete_from_db.
+     *
+     * @covers \package::delete_from_db
+     * @depends test_store_package_in_db
+     * @return void
+     * @throws moodle_exception
+     */
+    public function test_delete_from_db() {
+        global $DB;
+        $this->resetAfterTest();
+
+        $package = package_provider(['languages' => ['en', 'de'], 'tags' => ['tag_0']]);
+        $package->store_in_db();
+
+        $package->delete_from_db();
+        $this->assertEquals(0, $DB->count_records('qtype_questionpy_pkgversion'));
+        $this->assertEquals(0, $DB->count_records('qtype_questionpy_package'));
+        $this->assertEquals(0, $DB->count_records('qtype_questionpy_language'));
+        $this->assertEquals(0, $DB->count_records('qtype_questionpy_tags'));
+    }
+
+    /**
+     * Tests the method delete_from_db with multiple versions of the same package.
+     *
+     * @covers \package::delete_from_db
+     * @depends test_store_different_versions_of_package_in_db
+     * @return void
+     * @throws moodle_exception
+     */
+    public function test_delete_from_db_with_multiple_versions() {
+        global $DB;
+        $this->resetAfterTest();
+
+        $package1 = package_provider(['version' => '1.0.0', 'languages' => ['en'], 'tags' => ['tag_0']]);
+        $package2 = package_provider(['version' => '2.0.0', 'languages' => ['en'], 'tags' => ['tag_0']]);
+
+        $package1->store_in_db();
+        $package2->store_in_db();
+
+        $package1->delete_from_db();
+        $this->assertEquals(1, $DB->count_records('qtype_questionpy_pkgversion'));
+        $this->assertEquals(1, $DB->count_records('qtype_questionpy_package'));
+        $this->assertEquals(1, $DB->count_records('qtype_questionpy_language'));
+        $this->assertEquals(1, $DB->count_records('qtype_questionpy_tags'));
+
+        $package2->delete_from_db();
+        $this->assertEquals(0, $DB->count_records('qtype_questionpy_pkgversion'));
+        $this->assertEquals(0, $DB->count_records('qtype_questionpy_package'));
+        $this->assertEquals(0, $DB->count_records('qtype_questionpy_language'));
+        $this->assertEquals(0, $DB->count_records('qtype_questionpy_tags'));
+    }
+
+    /**
+     * Adds one package to db, then retrieves it. Tests if the retrieved package is the same as the original.
      *
      * @covers \qtype_questionpy\package::get_record_by_hash
+     * @depends test_store_package_in_db
      * @return void
-     * @throws \dml_exception
-     * @throws \moodle_exception
+     * @throws moodle_exception
      */
     public function test_storing_and_retrieving_one_package_from_db() {
-        global $DB;
-        $this->resetAfterTest(true);
+        $this->resetAfterTest();
 
-        $initial = package_provider1();
+        $initial = package_provider();
         $initial->store_in_db();
         [, $final] = package::get_record_by_hash($initial->hash);
 
@@ -191,8 +391,7 @@ class package_test extends \advanced_testcase {
      * @return void
      */
     public function test_retrieving_nonexistent_package_from_db() {
-        global $DB;
-        $package = package_provider1();
+        $package = package_provider();
         try {
             package::get_record_by_hash($package->hash);
             $this->fail('Package from data provider should not be in DB');
@@ -209,8 +408,8 @@ class package_test extends \advanced_testcase {
      * @return void
      */
     public function test_difference_from() {
-        $package1 = package_provider1();
-        $package2 = package_provider2();
+        $package1 = package_provider(['languages' => ['en', 'de']]);
+        $package2 = package_provider(['languages' => ['de', 'en']]);
 
         $difference = $package1->difference_from($package2);
         $this->assertNotEquals($package1, $package2, "Values in languages array should be swapped.");
@@ -224,18 +423,17 @@ class package_test extends \advanced_testcase {
      *
      * @covers \qtype_questionpy\package::get_records
      * @return void
-     * @throws \dml_exception
+     * @throws moodle_exception
      */
     public function test_get_records() {
-        global $DB;
         $this->resetAfterTest();
 
-        $package1 = package_provider1();
-        $package2 = package_provider2();
+        $package1 = package_provider();
+        $package2 = package_provider();
         $package1->store_in_db();
         $package2->store_in_db();
 
-        $packages = package::get_records(["hash" => "dkZZGAOgHTpBOSZMBGNM"]);
-        $this->assertTrue($package1->equals($packages[0]));
+        $packages = package::get_record_by_hash($package1->hash);
+        $this->assertTrue($package1->equals($packages[1]));
     }
 }


### PR DESCRIPTION
Mit diesem PR wird die Datenbankstruktur angepasst. Zusätzlich zu den bestehenden Tabellen, gibt es nun auch:
- qtype_questionpy_pkgversion
  *für versionsbezogene Daten (z.B. Hash und Version des Pakets)*
- *qtype_questionpy_lastused*
  *für Pakete die zuletzt verwendet wurden*

Außerdem sind die Tests etwas überarbeitet.