### PR TITLE
#38: Laufende Nummer in repetition_elements

### DIFF
--- a/classes/form/array_render_context.php
+++ b/classes/form/array_render_context.php
@@ -17,7 +17,6 @@
 namespace qtype_questionpy\form;
 
 use HTML_QuickForm_element;
-use qtype_questionpy\form\conditions\condition;
 use qtype_questionpy\form\elements\group_element;
 use qtype_questionpy\form\elements\repetition_element;
 use qtype_questionpy\utils;
@@ -36,6 +35,8 @@ use qtype_questionpy\utils;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class array_render_context extends render_context {
+    /** @var render_context context containing this group */
+    private render_context $parent;
     /**
      * @var HTML_QuickForm_element[] elements so far added to this group
      */
@@ -66,11 +67,12 @@ class array_render_context extends render_context {
     /**
      * Initializes a new array-based context.
      *
-     * @param render_context $root context containing this group
-     * @param string $prefix       prefix for the names of elements in this context
+     * @param render_context $parent context containing this group
+     * @param string $prefix         prefix for the names of elements in this context
      */
-    public function __construct(render_context $root, string $prefix) {
-        parent::__construct($root->moodleform, $root->mform, $prefix, $root->data, $root->nextuniqueint);
+    public function __construct(render_context $parent, string $prefix) {
+        $this->parent = $parent;
+        parent::__construct($parent->moodleform, $parent->mform, $prefix, $parent->data, $parent->nextuniqueint);
     }
 
     /**
@@ -168,5 +170,18 @@ class array_render_context extends render_context {
      */
     public function add_checkbox_controller(int $groupid): void {
         $this->moodleform->add_checkbox_controller($groupid);
+    }
+
+    /**
+     * Replaces occurrences of `{ qpy:... }` with the appropriate contextual variable, if any.
+     *
+     * This implementation just delegates to the parent context, so that repetition numbers are also replaced within
+     * groups.
+     *
+     * @param string $text string possibly containing `{ qpy:... }` format specifiers
+     * @return string input string with format specifiers replaced
+     */
+    public function contextualize(string $text): string {
+        return $this->parent->contextualize($text);
     }
 }

--- a/classes/form/context/array_render_context.php
+++ b/classes/form/context/array_render_context.php
@@ -178,10 +178,10 @@ class array_render_context extends render_context {
      * This implementation just delegates to the parent context, so that repetition numbers are also replaced within
      * groups.
      *
-     * @param string $text string possibly containing `{ qpy:... }` format specifiers
-     * @return string input string with format specifiers replaced
+     * @param string|null $text string possibly containing `{ qpy:... }` format specifiers
+     * @return string|null input string with format specifiers replaced
      */
-    public function contextualize(string $text): string {
+    public function contextualize(?string $text): ?string {
         return $this->parent->contextualize($text);
     }
 }

--- a/classes/form/context/array_render_context.php
+++ b/classes/form/context/array_render_context.php
@@ -14,20 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\form;
+namespace qtype_questionpy\form\context;
 
 use HTML_QuickForm_element;
 use qtype_questionpy\form\elements\group_element;
-use qtype_questionpy\form\elements\repetition_element;
 use qtype_questionpy\utils;
 
 /**
- * A {@see render_context} for {@see group_element groups} and {@see repetition_element repetitions}.
+ * A {@see render_context} for {@see group_element groups}.
  *
  * Instead of adding elements to the {@see \MoodleQuickForm}, they are added to an array which is later used to create
  * the group.
  *
- * @see        root_render_context
+ * @see        mform_render_context
  *
  * @package    qtype_questionpy
  * @author     Maximilian Haye
@@ -72,7 +71,10 @@ class array_render_context extends render_context {
      */
     public function __construct(render_context $parent, string $prefix) {
         $this->parent = $parent;
-        parent::__construct($parent->moodleform, $parent->mform, $prefix, $parent->data, $parent->nextuniqueint);
+        parent::__construct(
+            $parent->moodleform, $parent->mform, $prefix,
+            utils::array_get_nested($parent->data, $prefix) ?? []
+        );
     }
 
     /**
@@ -144,7 +146,7 @@ class array_render_context extends render_context {
      * @param mixed $value      for conditions requiring it, the value to compare with. Ignored otherwise.
      * @see \MoodleQuickForm::disabledIf()
      */
-    public function disable_if(string $dependant, string $dependency, string $operator, $value = null) {
+    public function disable_if(string $dependant, string $dependency, string $operator, $value = null): void {
         utils::ensure_exists($this->disableifs, $this->mangle_name($dependant))[] = [$dependency, $operator, $value];
     }
 
@@ -157,19 +159,17 @@ class array_render_context extends render_context {
      * @param mixed $value      for conditions requiring it, the value to compare with. Ignored otherwise.
      * @see \MoodleQuickForm::hideIf()
      */
-    public function hide_if(string $dependant, string $dependency, string $operator, $value = null) {
+    public function hide_if(string $dependant, string $dependency, string $operator, $value = null): void {
         utils::ensure_exists($this->hideifs, $this->mangle_name($dependant))[] = [$dependency, $operator, $value];
     }
 
     /**
-     * Adds a `Select all/none` checkbox controller controlling all `advcheckboxes` with the given group id.
+     * Get a unique and deterministic integer for use in generated element names and IDs.
      *
-     * @param int $groupid the group id matching the `group` attribute of the `advcheckboxes` which should be toggled
-     *                     by this controller.
-     * @see \moodleform::add_checkbox_controller()
+     * @return int a unique and deterministic integer for use in generated element names and IDs.
      */
-    public function add_checkbox_controller(int $groupid): void {
-        $this->moodleform->add_checkbox_controller($groupid);
+    public function next_unique_int(): int {
+        return $this->parent->next_unique_int();
     }
 
     /**

--- a/classes/form/context/mform_render_context.php
+++ b/classes/form/context/mform_render_context.php
@@ -14,10 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\form;
-
-use qtype_questionpy\form\conditions\condition;
-use qtype_questionpy\utils;
+namespace qtype_questionpy\form\context;
 
 /**
  * Regular {@see render_context} which delegates to {@see \moodleform} and {@see \MoodleQuickForm}.
@@ -26,23 +23,10 @@ use qtype_questionpy\utils;
  *
  * @package    qtype_questionpy
  * @author     Maximilian Haye
- * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class root_render_context extends render_context {
-    /**
-     * Creates an inner context by adding `$name` to the prefix and using `$data[$name]`.
-     *
-     * @param render_context $parent
-     * @param string $name nested name to be added to the prefix. May be made up of `multiple[parts]`.
-     * @return static
-     */
-    public static function create_inner(render_context $parent, string $name): self {
-        return new root_render_context(
-            $parent->moodleform, $parent->mform, $parent->mangle_name($name),
-            utils::array_get_nested($parent->data, $name) ?? [], $parent->nextuniqueint
-        );
-    }
+abstract class mform_render_context extends render_context {
 
     /**
      * Create, add and return an element.
@@ -103,37 +87,26 @@ class root_render_context extends render_context {
     /**
      * Adds a condition which will disable the named element if met.
      *
-     * @param string $dependant name of the element which has the dependency on another element
-     * @param string $dependency  absolute name of the element which is depended on
-     * @param string $operator  one of a fixed set of conditions, as in {@see MoodleQuickForm::disabledIf}
-     * @param mixed $value      for conditions requiring it, the value to compare with. Ignored otherwise.
+     * @param string $dependant  name of the element which has the dependency on another element
+     * @param string $dependency absolute name of the element which is depended on
+     * @param string $operator   one of a fixed set of conditions, as in {@see MoodleQuickForm::disabledIf}
+     * @param mixed $value       for conditions requiring it, the value to compare with. Ignored otherwise.
      * @see \MoodleQuickForm::disabledIf()
      */
-    public function disable_if(string $dependant, string $dependency, string $operator, $value = null) {
+    public function disable_if(string $dependant, string $dependency, string $operator, $value = null): void {
         $this->mform->disabledIf($this->mangle_name($dependant), $dependency, $operator, $value);
     }
 
     /**
      * Adds a condition which will hide the named element if met.
      *
-     * @param string $dependant name of the element which has the dependency on another element
-     * @param string $dependency  absolute name of the element which is depended on
-     * @param string $operator  one of a fixed set of conditions, as in {@see MoodleQuickForm::hideIf}
-     * @param mixed $value      for conditions requiring it, the value to compare with. Ignored otherwise.
+     * @param string $dependant  name of the element which has the dependency on another element
+     * @param string $dependency absolute name of the element which is depended on
+     * @param string $operator   one of a fixed set of conditions, as in {@see MoodleQuickForm::hideIf}
+     * @param mixed $value       for conditions requiring it, the value to compare with. Ignored otherwise.
      * @see \MoodleQuickForm::hideIf()
      */
-    public function hide_if(string $dependant, string $dependency, string $operator, $value = null) {
+    public function hide_if(string $dependant, string $dependency, string $operator, $value = null): void {
         $this->mform->hideIf($this->mangle_name($dependant), $dependency, $operator, $value);
-    }
-
-    /**
-     * Adds a `Select all/none` checkbox controller controlling all `advcheckboxes` with the given group id.
-     *
-     * @param int $groupid the group id matching the `group` attribute of the `advcheckboxes` which should be toggled
-     *                     by this controller.
-     * @see \moodleform::add_checkbox_controller()
-     */
-    public function add_checkbox_controller(int $groupid): void {
-        $this->moodleform->add_checkbox_controller($groupid);
     }
 }

--- a/classes/form/context/mform_render_context.php
+++ b/classes/form/context/mform_render_context.php
@@ -16,6 +16,8 @@
 
 namespace qtype_questionpy\form\context;
 
+use qtype_questionpy\utils;
+
 /**
  * Regular {@see render_context} which delegates to {@see \moodleform} and {@see \MoodleQuickForm}.
  *
@@ -61,7 +63,9 @@ abstract class mform_render_context extends render_context {
      * @see \MoodleQuickForm::setDefault()
      */
     public function set_default(string $name, $default): void {
-        $this->mform->setDefault($this->mangle_name($name), $default);
+        /* We cannot use setDefault because that method uses $name as a top-level key instead of using nested arrays,
+           which causes elements to prefer defaults over saved question data. (#44) */
+        $this->mform->setDefaults(utils::array_create_nested($this->mangle_name($name), $default));
     }
 
     /**

--- a/classes/form/context/render_context.php
+++ b/classes/form/context/render_context.php
@@ -208,8 +208,8 @@ abstract class render_context {
      * This is used by {@see repetition_render_context} to allow repeated elements to show the repetition number without
      * the elements needing to be aware of whether they are in a repetition.
      *
-     * @param string $text string possibly containing `{ qpy:... }` format specifiers
-     * @return string input string with format specifiers replaced
+     * @param string|null $text string possibly containing `{ qpy:... }` format specifiers
+     * @return string|null input string with format specifiers replaced
      */
-    public abstract function contextualize(string $text): string;
+    public abstract function contextualize(?string $text): ?string;
 }

--- a/classes/form/context/render_context.php
+++ b/classes/form/context/render_context.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\form;
+namespace qtype_questionpy\form\context;
 
 use moodleform;
 use MoodleQuickForm;
@@ -28,7 +28,10 @@ use qtype_questionpy\utils;
  * aware of where they are being rendered. It does this while still allowing for checkbox controllers, which use an
  * entirely different method.
  *
- * @see        root_render_context
+ * Render contexts form a hierarchy with a single {@see root_render_context} at the top and 0 or more
+ * {@see section_render_context}s and {@see array_render_context}s below it.
+ *
+ * @see        mform_render_context
  * @see        array_render_context
  * @package    qtype_questionpy
  * @author     Maximilian Haye
@@ -40,7 +43,7 @@ abstract class render_context {
     public moodleform $moodleform;
     /**
      * @var MoodleQuickForm target {@see MoodleQuickForm} instance, as passed to
-     *      {@see \question_edit_form::definition_inner}
+     *                      {@see \question_edit_form::definition_inner}
      */
     public MoodleQuickForm $mform;
 
@@ -50,9 +53,6 @@ abstract class render_context {
     /** @var array the current form data */
     public array $data;
 
-    /** @var int the next int which will be returned by {@see next_unique_int} */
-    public int $nextuniqueint;
-
     /**
      * Initializes a new render context.
      *
@@ -61,15 +61,12 @@ abstract class render_context {
      *                                {@see \question_edit_form::definition_inner}
      * @param string $prefix          prefix for the names of elements in this context
      * @param array $data             the current form data (as of last save)
-     * @param int $nextuniqueint      the starting value for {@see next_unique_int}
      */
-    public function __construct(moodleform $moodleform, MoodleQuickForm $mform, string $prefix, array $data,
-                                int        $nextuniqueint = 1) {
+    public function __construct(moodleform $moodleform, MoodleQuickForm $mform, string $prefix, array $data) {
         $this->moodleform = $moodleform;
         $this->mform = $mform;
         $this->prefix = $prefix;
         $this->data = $data;
-        $this->nextuniqueint = $nextuniqueint;
     }
 
     /**
@@ -129,7 +126,7 @@ abstract class render_context {
      * @param mixed $value      for conditions requiring it, the value to compare with. Ignored otherwise.
      * @see MoodleQuickForm::disabledIf
      */
-    abstract public function disable_if(string $dependant, string $dependency, string $operator, $value = null);
+    abstract public function disable_if(string $dependant, string $dependency, string $operator, $value = null): void;
 
     /**
      * Adds a condition which will hide the named element if met.
@@ -140,16 +137,7 @@ abstract class render_context {
      * @param mixed $value      for conditions requiring it, the value to compare with. Ignored otherwise.
      * @see MoodleQuickForm::hideIf
      */
-    abstract public function hide_if(string $dependant, string $dependency, string $operator, $value = null);
-
-    /**
-     * Adds a `Select all/none` checkbox controller controlling all `advcheckboxes` with the given group id.
-     *
-     * @param int $groupid the group id matching the `group` attribute of the `advcheckboxes` which should be toggled
-     *                     by this controller.
-     * @see moodleform::add_checkbox_controller
-     */
-    abstract public function add_checkbox_controller(int $groupid): void;
+    abstract public function hide_if(string $dependant, string $dependency, string $operator, $value = null): void;
 
     /**
      * Append the given local name to the prefix of this context.
@@ -179,9 +167,7 @@ abstract class render_context {
      *
      * @return int a unique and deterministic integer for use in generated element names and IDs.
      */
-    public function next_unique_int(): int {
-        return $this->nextuniqueint++;
-    }
+    public abstract function next_unique_int(): int;
 
     /**
      * Turns a reference relative to this context's prefix into an absolute reference.
@@ -225,8 +211,5 @@ abstract class render_context {
      * @param string $text string possibly containing `{ qpy:... }` format specifiers
      * @return string input string with format specifiers replaced
      */
-    public function contextualize(string $text): string {
-        // Dummy implementation to be replaced in repetition_render_context and possibly extended in the future.
-        return $text;
-    }
+    public abstract function contextualize(string $text): string;
 }

--- a/classes/form/context/render_context.php
+++ b/classes/form/context/render_context.php
@@ -167,7 +167,7 @@ abstract class render_context {
      *
      * @return int a unique and deterministic integer for use in generated element names and IDs.
      */
-    public abstract function next_unique_int(): int;
+    abstract public function next_unique_int(): int;
 
     /**
      * Turns a reference relative to this context's prefix into an absolute reference.
@@ -211,5 +211,5 @@ abstract class render_context {
      * @param string|null $text string possibly containing `{ qpy:... }` format specifiers
      * @return string|null input string with format specifiers replaced
      */
-    public abstract function contextualize(?string $text): ?string;
+    abstract public function contextualize(?string $text): ?string;
 }

--- a/classes/form/context/repetition_render_context.php
+++ b/classes/form/context/repetition_render_context.php
@@ -50,10 +50,14 @@ class repetition_render_context extends section_render_context {
     /**
      * Replaces occurrences of `{ qpy:repno }` with the current repetition number.
      *
-     * @param string $text string possibly containing `{ qpy:repno }` format specifiers
-     * @return string input string with format specifiers replaced
+     * @param string|null $text string possibly containing `{ qpy:repno }` format specifiers
+     * @return string|null input string with format specifiers replaced
      */
-    public function contextualize(string $text): string {
+    public function contextualize(?string $text): ?string {
+        if (!$text) {
+            return $text;
+        }
+
         $text = preg_replace('/\{\s*qpy:repno\s*}/', $this->humanrepno, $text);
         return parent::contextualize($text);
     }

--- a/classes/form/context/repetition_render_context.php
+++ b/classes/form/context/repetition_render_context.php
@@ -14,10 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\form;
+namespace qtype_questionpy\form\context;
 
 use qtype_questionpy\form\elements\repetition_element;
-use qtype_questionpy\utils;
 
 /**
  * Special {@see render_context} for a single iteration of a {@see repetition_element}.
@@ -30,7 +29,7 @@ use qtype_questionpy\utils;
  * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class repetition_render_context extends root_render_context {
+class repetition_render_context extends section_render_context {
 
     /** @var int running number of this repetition iteration, starting at 1 and not counting removed reps */
     private int $humanrepno;
@@ -39,17 +38,13 @@ class repetition_render_context extends root_render_context {
      * Initializes a context for a single iteration of a {@see repetition_element}.
      *
      * @param render_context $parent context containing the repetition
-     * @param string $name name of the repetition, without index
-     * @param int $repno running number of this repetition iteration, starting at 0 and also counting removed reps
-     * @param int $humanrepno running number of this repetition iteration, starting at 1 and not counting removed reps
+     * @param string $name           name of the repetition, without index
+     * @param int $repno             running number of this repetition iteration, starting at 0 and also counting removed reps
+     * @param int $humanrepno        running number of this repetition iteration, starting at 1 and not counting removed reps
      */
     public function __construct(render_context $parent, string $name, int $repno, int $humanrepno) {
         $this->humanrepno = $humanrepno;
-        parent::__construct(
-            $parent->moodleform, $parent->mform,
-            $parent->mangle_name($name . "[$repno]"),
-            utils::array_get_nested($parent->data, $name) ?? [], $parent->nextuniqueint
-        );
+        parent::__construct($parent, $name . "[$repno]");
     }
 
     /**
@@ -59,6 +54,7 @@ class repetition_render_context extends root_render_context {
      * @return string input string with format specifiers replaced
      */
     public function contextualize(string $text): string {
-        return preg_replace('/\{\s*qpy:repno\s*}/', $this->humanrepno, $text);
+        $text = preg_replace('/\{\s*qpy:repno\s*}/', $this->humanrepno, $text);
+        return parent::contextualize($text);
     }
 }

--- a/classes/form/context/root_render_context.php
+++ b/classes/form/context/root_render_context.php
@@ -14,48 +14,39 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\form\elements;
-
-use qtype_questionpy\form\context\render_context;
-use qtype_questionpy\form\form_conditions;
+namespace qtype_questionpy\form\context;
 
 /**
- * Element which is not displayed at all, but adds a fixed name/value pair to the form data upon submission.
+ * Uppermost render context.
  *
  * @package    qtype_questionpy
  * @author     Maximilian Haye
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class hidden_element extends form_element {
-    /** @var string */
-    public string $name;
-    /** @var string */
-    public string $value;
+class root_render_context extends mform_render_context {
 
-    use form_conditions;
+    /** @var int the next int which will be returned by {@see next_unique_int} */
+    private int $nextuniqueint = 1;
 
     /**
-     * Initializes the element.
+     * Get a unique and deterministic integer for use in generated element names and IDs.
      *
-     * @param string $name
-     * @param string $value
+     * @return int a unique and deterministic integer for use in generated element names and IDs.
      */
-    public function __construct(string $name, string $value) {
-        $this->name = $name;
-        $this->value = $value;
+    public function next_unique_int(): int {
+        return $this->nextuniqueint++;
     }
 
     /**
-     * Render this item to the given context.
+     * Replaces occurrences of `{ qpy:... }` with the appropriate contextual variable, if any.
      *
-     * @param render_context $context target context
-     * @package qtype_questionpy
+     * This render context returns the string unchanged.
+     *
+     * @param string $text string possibly containing `{ qpy:... }` format specifiers
+     * @return string input string with format specifiers replaced
      */
-    public function render_to(render_context $context): void {
-        $context->add_element("hidden", $this->name, $this->value);
-        $context->set_type($this->name, PARAM_TEXT);
-
-        $this->render_conditions($context, $this->name);
+    public function contextualize(string $text): string {
+        return $text;
     }
 }

--- a/classes/form/context/root_render_context.php
+++ b/classes/form/context/root_render_context.php
@@ -43,10 +43,10 @@ class root_render_context extends mform_render_context {
      *
      * This render context returns the string unchanged.
      *
-     * @param string $text string possibly containing `{ qpy:... }` format specifiers
-     * @return string input string with format specifiers replaced
+     * @param string|null $text string possibly containing `{ qpy:... }` format specifiers
+     * @return string|null input string with format specifiers replaced
      */
-    public function contextualize(string $text): string {
+    public function contextualize(?string $text): ?string {
         return $text;
     }
 }

--- a/classes/form/context/section_render_context.php
+++ b/classes/form/context/section_render_context.php
@@ -62,10 +62,10 @@ class section_render_context extends mform_render_context {
      * This implementation just delegates to the parent context, so that repetition numbers are also replaced within
      * groups.
      *
-     * @param string $text string possibly containing `{ qpy:... }` format specifiers
-     * @return string input string with format specifiers replaced
+     * @param string|null $text string possibly containing `{ qpy:... }` format specifiers
+     * @return string|null input string with format specifiers replaced
      */
-    public function contextualize(string $text): string {
+    public function contextualize(?string $text): ?string {
         return $this->parent->contextualize($text);
     }
 }

--- a/classes/form/context/section_render_context.php
+++ b/classes/form/context/section_render_context.php
@@ -1,0 +1,71 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\form\context;
+
+use qtype_questionpy\utils;
+
+/**
+ * A nested render context.
+ *
+ * @see        root_render_context
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class section_render_context extends mform_render_context {
+    /** @var render_context context containing this section */
+    private render_context $parent;
+
+    /**
+     * Initializes a new {@see section_render_context}.
+     *
+     * @param render_context $parent context containing this section
+     * @param string $name           the name part which will be appended to `$parent`'s prefix
+     */
+    public function __construct(render_context $parent, string $name) {
+        $this->parent = $parent;
+        parent::__construct(
+            $parent->moodleform, $parent->mform,
+            $parent->mangle_name($name),
+            utils::array_get_nested($parent->data, $name) ?? []
+        );
+    }
+
+    /**
+     * Get a unique and deterministic integer for use in generated element names and IDs.
+     *
+     * @return int a unique and deterministic integer for use in generated element names and IDs.
+     */
+    public function next_unique_int(): int {
+        return $this->parent->next_unique_int();
+    }
+
+    /**
+     * Replaces occurrences of `{ qpy:... }` with the appropriate contextual variable, if any.
+     *
+     * This implementation just delegates to the parent context, so that repetition numbers are also replaced within
+     * groups.
+     *
+     * @param string $text string possibly containing `{ qpy:... }` format specifiers
+     * @return string input string with format specifiers replaced
+     */
+    public function contextualize(string $text): string {
+        return $this->parent->contextualize($text);
+    }
+}

--- a/classes/form/elements/checkbox_element.php
+++ b/classes/form/elements/checkbox_element.php
@@ -75,7 +75,9 @@ class checkbox_element extends form_element {
      */
     public function render_to(render_context $context, ?int $group = null): void {
         $element = $context->add_element(
-            "advcheckbox", $this->name, $this->leftlabel, $this->rightlabel,
+            "advcheckbox", $this->name,
+            $context->contextualize($this->leftlabel),
+            $context->contextualize($this->rightlabel),
             $group ? ["group" => $group] : null
         );
 

--- a/classes/form/elements/checkbox_element.php
+++ b/classes/form/elements/checkbox_element.php
@@ -19,9 +19,9 @@ namespace qtype_questionpy\form\elements;
 use coding_exception;
 use qtype_questionpy\array_converter\array_converter;
 use qtype_questionpy\array_converter\converter_config;
+use qtype_questionpy\form\context\render_context;
 use qtype_questionpy\form\form_conditions;
 use qtype_questionpy\form\form_help;
-use qtype_questionpy\form\render_context;
 
 defined('MOODLE_INTERNAL') || die;
 

--- a/classes/form/elements/checkbox_group_element.php
+++ b/classes/form/elements/checkbox_group_element.php
@@ -19,7 +19,7 @@ namespace qtype_questionpy\form\elements;
 use coding_exception;
 use qtype_questionpy\array_converter\array_converter;
 use qtype_questionpy\array_converter\converter_config;
-use qtype_questionpy\form\render_context;
+use qtype_questionpy\form\context\render_context;
 
 defined('MOODLE_INTERNAL') || die;
 
@@ -58,7 +58,7 @@ class checkbox_group_element extends form_element {
             $checkbox->render_to($context, $groupid);
         }
 
-        $context->add_checkbox_controller($groupid);
+        $context->moodleform->add_checkbox_controller($groupid);
     }
 }
 

--- a/classes/form/elements/group_element.php
+++ b/classes/form/elements/group_element.php
@@ -18,10 +18,10 @@ namespace qtype_questionpy\form\elements;
 
 use qtype_questionpy\array_converter\array_converter;
 use qtype_questionpy\array_converter\converter_config;
-use qtype_questionpy\form\array_render_context;
+use qtype_questionpy\form\context\array_render_context;
+use qtype_questionpy\form\context\render_context;
 use qtype_questionpy\form\form_conditions;
 use qtype_questionpy\form\form_help;
-use qtype_questionpy\form\render_context;
 
 defined('MOODLE_INTERNAL') || die;
 
@@ -99,8 +99,6 @@ class group_element extends form_element {
 
         $this->render_conditions($context, $groupname);
         $this->render_help($element);
-
-        $context->nextuniqueint = $innercontext->nextuniqueint;
     }
 }
 

--- a/classes/form/elements/group_element.php
+++ b/classes/form/elements/group_element.php
@@ -71,7 +71,11 @@ class group_element extends form_element {
             $element->render_to($innercontext);
         }
 
-        $element = $context->add_element("group", $groupname, $this->label, $innercontext->elements, null, false);
+        $element = $context->add_element(
+            "group", $groupname,
+            $context->contextualize($this->label),
+            $innercontext->elements, null, false
+        );
 
         foreach ($innercontext->types as $name => $type) {
             $context->set_type($name, $type);

--- a/classes/form/elements/radio_group_element.php
+++ b/classes/form/elements/radio_group_element.php
@@ -73,10 +73,16 @@ class radio_group_element extends form_element {
                 $default = $option->value;
             }
 
-            $radioarray[] = $context->mform->createElement("radio", $mangledname, null, $option->label, $option->value);
+            $radioarray[] = $context->mform->createElement(
+                "radio", $mangledname, null,
+                $context->contextualize($option->label), $option->value
+            );
         }
 
-        $group = $context->add_element("group", "radio_group_" . $this->name, $this->label, $radioarray, null, false);
+        $group = $context->add_element(
+            "group", "radio_group_" . $this->name, $context->contextualize($this->label),
+            $radioarray, null, false
+        );
 
         if ($default) {
             $context->set_default($this->name, $default);

--- a/classes/form/elements/radio_group_element.php
+++ b/classes/form/elements/radio_group_element.php
@@ -18,9 +18,9 @@ namespace qtype_questionpy\form\elements;
 
 use qtype_questionpy\array_converter\array_converter;
 use qtype_questionpy\array_converter\converter_config;
+use qtype_questionpy\form\context\render_context;
 use qtype_questionpy\form\form_conditions;
 use qtype_questionpy\form\form_help;
-use qtype_questionpy\form\render_context;
 
 defined('MOODLE_INTERNAL') || die;
 

--- a/classes/form/elements/repetition_element.php
+++ b/classes/form/elements/repetition_element.php
@@ -19,8 +19,8 @@ namespace qtype_questionpy\form\elements;
 use coding_exception;
 use qtype_questionpy\array_converter\array_converter;
 use qtype_questionpy\array_converter\converter_config;
-use qtype_questionpy\form\render_context;
-use qtype_questionpy\form\repetition_render_context;
+use qtype_questionpy\form\context\render_context;
+use qtype_questionpy\form\context\repetition_render_context;
 
 defined('MOODLE_INTERNAL') || die;
 
@@ -137,7 +137,6 @@ class repetition_element extends form_element {
             foreach ($this->elements as $element) {
                 $element->render_to($innercontext);
             }
-            $context->nextuniqueint = $innercontext->nextuniqueint;
 
             $context->mform->addElement("html", '</div><div class="qpy-repetition-controls">');
             if ($allowremoval) {

--- a/classes/form/elements/repetition_element.php
+++ b/classes/form/elements/repetition_element.php
@@ -20,7 +20,7 @@ use coding_exception;
 use qtype_questionpy\array_converter\array_converter;
 use qtype_questionpy\array_converter\converter_config;
 use qtype_questionpy\form\render_context;
-use qtype_questionpy\form\root_render_context;
+use qtype_questionpy\form\repetition_render_context;
 
 defined('MOODLE_INTERNAL') || die;
 
@@ -123,14 +123,17 @@ class repetition_element extends form_element {
         global $OUTPUT;
         $removeicon = $OUTPUT->pix_icon('i/delete', $removestring, 'core');
 
+        // User-facing repetition number. Starts at 1 and doesn't count removed reps.
+        $humanrepno = 0;
         for ($i = 0; $i < $repeats; $i++) {
             if (in_array($i, $removed)) {
                 continue;
             }
+            $humanrepno++;
 
             $context->mform->addElement("html", '<div class="qpy-repetition"><div class="qpy-repetition-content">');
 
-            $innercontext = root_render_context::create_inner($context, $this->name . "[$i]");
+            $innercontext = new repetition_render_context($context, $this->name, $i, $humanrepno);
             foreach ($this->elements as $element) {
                 $element->render_to($innercontext);
             }

--- a/classes/form/elements/select_element.php
+++ b/classes/form/elements/select_element.php
@@ -19,9 +19,9 @@ namespace qtype_questionpy\form\elements;
 use HTML_QuickForm_select;
 use qtype_questionpy\array_converter\array_converter;
 use qtype_questionpy\array_converter\converter_config;
+use qtype_questionpy\form\context\render_context;
 use qtype_questionpy\form\form_conditions;
 use qtype_questionpy\form\form_help;
-use qtype_questionpy\form\render_context;
 
 defined('MOODLE_INTERNAL') || die;
 

--- a/classes/form/elements/select_element.php
+++ b/classes/form/elements/select_element.php
@@ -74,7 +74,7 @@ class select_element extends form_element {
         $selected = [];
         $optionsassociative = [];
         foreach ($this->options as $option) {
-            $optionsassociative[$option->value] = $option->label;
+            $optionsassociative[$option->value] = $context->contextualize($option->label);
             if ($option->selected) {
                 $selected[] = $option->value;
             }
@@ -82,7 +82,9 @@ class select_element extends form_element {
 
         // phpcs:disable moodle.Commenting.InlineComment.DocBlock
         /** @var $element HTML_QuickForm_select */
-        $element = $context->add_element("select", $this->name, $this->label, $optionsassociative);
+        $element = $context->add_element(
+            "select", $this->name,
+            $context->contextualize($this->label), $optionsassociative);
 
         $element->setMultiple($this->multiple);
         if ($selected) {

--- a/classes/form/elements/static_text_element.php
+++ b/classes/form/elements/static_text_element.php
@@ -16,9 +16,9 @@
 
 namespace qtype_questionpy\form\elements;
 
+use qtype_questionpy\form\context\render_context;
 use qtype_questionpy\form\form_conditions;
 use qtype_questionpy\form\form_help;
-use qtype_questionpy\form\render_context;
 
 /**
  * Element displaying static text and a label.

--- a/classes/form/elements/static_text_element.php
+++ b/classes/form/elements/static_text_element.php
@@ -57,7 +57,10 @@ class static_text_element extends form_element {
      * @param render_context $context target context
      */
     public function render_to(render_context $context): void {
-        $element = $context->add_element("static", $this->name, $this->label, $this->text);
+        $element = $context->add_element(
+            "static", $this->name,
+            $context->contextualize($this->label), $context->contextualize($this->text)
+        );
 
         $this->render_conditions($context, $this->name);
         $this->render_help($element);

--- a/classes/form/elements/text_input_element.php
+++ b/classes/form/elements/text_input_element.php
@@ -71,13 +71,14 @@ class text_input_element extends form_element {
      * @param render_context $context target context
      */
     public function render_to(render_context $context): void {
-        $attributes = $this->placeholder ? ["placeholder" => $this->placeholder] : [];
+        $attributes = $this->placeholder ? ["placeholder" => $context->contextualize($this->placeholder)] : [];
 
-        $element = $context->add_element("text", $this->name, $this->label, $attributes);
+        $element = $context->add_element(
+            "text", $this->name, $context->contextualize($this->label), $attributes);
         $context->set_type($this->name, PARAM_TEXT);
 
         if ($this->default) {
-            $context->set_default($this->name, $this->default);
+            $context->set_default($this->name, $context->contextualize($this->default));
         }
         if ($this->required) {
             $context->add_rule($this->name, null, "required");

--- a/classes/form/elements/text_input_element.php
+++ b/classes/form/elements/text_input_element.php
@@ -16,9 +16,9 @@
 
 namespace qtype_questionpy\form\elements;
 
+use qtype_questionpy\form\context\render_context;
 use qtype_questionpy\form\form_conditions;
 use qtype_questionpy\form\form_help;
-use qtype_questionpy\form\render_context;
 
 /**
  * Simple text input element.

--- a/classes/form/form_conditions.php
+++ b/classes/form/form_conditions.php
@@ -19,6 +19,7 @@ namespace qtype_questionpy\form;
 use qtype_questionpy\array_converter\array_converter;
 use qtype_questionpy\array_converter\converter_config;
 use qtype_questionpy\form\conditions\condition;
+use qtype_questionpy\form\context\render_context;
 
 defined('MOODLE_INTERNAL') || die;
 

--- a/classes/form/form_section.php
+++ b/classes/form/form_section.php
@@ -18,6 +18,8 @@ namespace qtype_questionpy\form;
 
 use qtype_questionpy\array_converter\array_converter;
 use qtype_questionpy\array_converter\converter_config;
+use qtype_questionpy\form\context\render_context;
+use qtype_questionpy\form\context\section_render_context;
 use qtype_questionpy\form\elements\form_element;
 
 defined('MOODLE_INTERNAL') || die;
@@ -62,11 +64,10 @@ class form_section implements qpy_renderable {
     public function render_to(render_context $context): void {
         $mangled = $context->mangle_name($this->name);
         $context->add_element("header", $mangled, $this->header);
-        $innercontext = root_render_context::create_inner($context, $this->name);
+        $innercontext = new section_render_context($context, $this->name);
         foreach ($this->elements as $element) {
             $element->render_to($innercontext);
         }
-        $context->nextuniqueint = $innercontext->nextuniqueint;
     }
 }
 

--- a/classes/form/qpy_form.php
+++ b/classes/form/qpy_form.php
@@ -18,6 +18,7 @@ namespace qtype_questionpy\form;
 
 use qtype_questionpy\array_converter\array_converter;
 use qtype_questionpy\array_converter\converter_config;
+use qtype_questionpy\form\context\render_context;
 use qtype_questionpy\form\elements\form_element;
 
 defined('MOODLE_INTERNAL') || die;

--- a/classes/form/qpy_renderable.php
+++ b/classes/form/qpy_renderable.php
@@ -16,6 +16,7 @@
 
 namespace qtype_questionpy\form;
 
+use qtype_questionpy\form\context\render_context;
 use qtype_questionpy\form\elements\form_element;
 
 /**

--- a/classes/form/render_context.php
+++ b/classes/form/render_context.php
@@ -18,7 +18,6 @@ namespace qtype_questionpy\form;
 
 use moodleform;
 use MoodleQuickForm;
-use qtype_questionpy\form\conditions\condition;
 use qtype_questionpy\utils;
 
 /**
@@ -213,5 +212,21 @@ abstract class render_context {
 
         // Stitch $refereeparts back together.
         return $refereeparts[0] . "[" . implode("][", array_slice($refereeparts, 1)) . "]";
+    }
+
+    /**
+     * Replaces occurrences of `{ qpy:... }` with the appropriate contextual variable, if any.
+     *
+     * Unrecognized variables aren't replaced at all.
+     *
+     * This is used by {@see repetition_render_context} to allow repeated elements to show the repetition number without
+     * the elements needing to be aware of whether they are in a repetition.
+     *
+     * @param string $text string possibly containing `{ qpy:... }` format specifiers
+     * @return string input string with format specifiers replaced
+     */
+    public function contextualize(string $text): string {
+        // Dummy implementation to be replaced in repetition_render_context and possibly extended in the future.
+        return $text;
     }
 }

--- a/classes/form/repetition_render_context.php
+++ b/classes/form/repetition_render_context.php
@@ -1,0 +1,64 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\form;
+
+use qtype_questionpy\form\elements\repetition_element;
+use qtype_questionpy\utils;
+
+/**
+ * Special {@see render_context} for a single iteration of a {@see repetition_element}.
+ *
+ * @see        root_render_context
+ * @see        array_render_context
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class repetition_render_context extends root_render_context {
+
+    /** @var int running number of this repetition iteration, starting at 1 and not counting removed reps */
+    private int $humanrepno;
+
+    /**
+     * Initializes a context for a single iteration of a {@see repetition_element}.
+     *
+     * @param render_context $parent context containing the repetition
+     * @param string $name name of the repetition, without index
+     * @param int $repno running number of this repetition iteration, starting at 0 and also counting removed reps
+     * @param int $humanrepno running number of this repetition iteration, starting at 1 and not counting removed reps
+     */
+    public function __construct(render_context $parent, string $name, int $repno, int $humanrepno) {
+        $this->humanrepno = $humanrepno;
+        parent::__construct(
+            $parent->moodleform, $parent->mform,
+            $parent->mangle_name($name . "[$repno]"),
+            utils::array_get_nested($parent->data, $name) ?? [], $parent->nextuniqueint
+        );
+    }
+
+    /**
+     * Replaces occurrences of `{ qpy:repno }` with the current repetition number.
+     *
+     * @param string $text string possibly containing `{ qpy:repno }` format specifiers
+     * @return string input string with format specifiers replaced
+     */
+    public function contextualize(string $text): string {
+        return preg_replace('/\{\s*qpy:repno\s*}/', $this->humanrepno, $text);
+    }
+}

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -16,7 +16,6 @@
 
 namespace qtype_questionpy;
 
-use Generator;
 use qtype_questionpy\form\elements\repetition_element;
 
 /**
@@ -78,6 +77,30 @@ class utils {
         }
 
         return $current;
+    }
+
+    /**
+     * Given a key such as `abc[def]`, returns an array `[ "abc" => [ "def" => $value ] ]`.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return array
+     */
+    public static function array_create_nested(string $key, $value): array {
+        // Explode a $name like qpy_form[abc][def] into an array ["qpy_form", "abc", "def"].
+        $parts = explode("[", str_replace("]", "", $key));
+
+        $array = [];
+        $current = &$array;
+        foreach ($parts as $key) {
+            if (!is_array($current)) {
+                $current = [];
+            }
+            $current = &$current[$key];
+        }
+        $current = $value;
+
+        return $array;
     }
 
     /**

--- a/edit_questionpy_form.php
+++ b/edit_questionpy_form.php
@@ -23,10 +23,8 @@
  */
 
 use qtype_questionpy\api\api;
-use qtype_questionpy\form\elements\text_input_element;
-use qtype_questionpy\form\root_render_context;
+use qtype_questionpy\form\context\root_render_context;
 use qtype_questionpy\localizer;
-use qtype_questionpy\utils;
 
 /**
  * QuestionPy question editing form definition.

--- a/tests/form/elements/element_html_test.php
+++ b/tests/form/elements/element_html_test.php
@@ -45,9 +45,9 @@ class element_html_test extends \advanced_testcase {
      * @param qpy_renderable $element element to render
      * @dataProvider data_provider
      * @covers       \qtype_questionpy\form\elements
-     * @covers       \qtype_questionpy\form\render_context
-     * @covers       \qtype_questionpy\form\root_render_context
-     * @covers       \qtype_questionpy\form\array_render_context
+     * @covers       \qtype_questionpy\form\context\render_context
+     * @covers       \qtype_questionpy\form\context\root_render_context
+     * @covers       \qtype_questionpy\form\context\array_render_context
      * @covers       \qtype_questionpy\form\qpy_renderable
      */
     public function test_rendered_html_should_match_snapshot(string $elementkind, qpy_renderable $element): void {

--- a/tests/form/elements/test_moodleform.php
+++ b/tests/form/elements/test_moodleform.php
@@ -21,8 +21,8 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 require_once($CFG->libdir . "/formslib.php");
 
+use qtype_questionpy\form\context\root_render_context;
 use qtype_questionpy\form\qpy_renderable;
-use qtype_questionpy\form\root_render_context;
 
 /**
  * Stub {@see \moodleform} implementation for tests.


### PR DESCRIPTION
Erlaubt es dem Paket, in u.a. Labels die laufende Nummer der aktuellen Wiederholung eines `repetition_element`s anzuzeigen. Dafür kann das Paket `{ qpy:repno }` in das Label einbauen, was dann ersetzt wird. Das funktioniert auch verschachtelt, z.B. kann eine Select-Option in einer Gruppe in einer Repetition das verwenden. Sollte ein Label außerhalb einer Repetition so einen Substring enthalten, passiert damit nichts, es würde also einfach so angezeigt werden. Vielleicht wäre es sinnvoll, im SDK trotzdem zu prüfen, dass der Fehler nicht gemacht wird.

Das `qpy:` in `{ qpy:repno }` ist gewählt, um Kollisionen zu vermeiden. (Falls jmd wirklich mal `{no}` in einem Label verbauen will.) Mir fällt ganz akut wenig ein, aber es wäre denkbar, andere Dinge nach dem Schema `{ qpy:... }` ersetzen zu lassen. In Python tendiere ich dazu, das über f-strings einbauen zu lassen: `f"Mein komisches Label Nr. {repeat.number}"`.

Konkret in Folgendem wird das unterstützt:
* **checkbox_element**: `left_label` und `right_label`
* **group_element**: `label`
* **radio_group_element**: `label` und die `label`s der Optionen
* **select_element**: `label` und die `label`s der Optionen
* **static_text_element**: `label`, `text`
* **text_input_element**: `label`, `default`, `placeholder`

Btw: Der zweite Commit ist wirklich nur Refactoring. Auch interessant, ändert aber nichts an der Funktionalität.

Closes #38 