### PR TITLE
Fragen Anzeigen / Question XML I

### DIFF
--- a/classes/question_metadata.php
+++ b/classes/question_metadata.php
@@ -1,0 +1,40 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy;
+
+/**
+ * Metadata about a question attempt, extracted by {@see question_ui} from the XML.
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class question_metadata {
+
+    /**
+     * @var array|null if known, an array of `name => correct_value` entries for the expected response fields
+     * @see \qtype_renderer::correct_response()
+     */
+    public ?array $correctresponse = null;
+
+    /**
+     * @var array an array of `name => PARAM_X` entries for the expected response fields
+     * @see \question_definition::get_expected_data()
+     */
+    public array $expecteddata = [];
+}

--- a/classes/question_ui.php
+++ b/classes/question_ui.php
@@ -1,0 +1,210 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy;
+
+use coding_exception;
+use DOMAttr;
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+use qtype_questionpy\question_ui\cleanup_transformation;
+use qtype_questionpy\question_ui\feedback_transformation;
+use qtype_questionpy\question_ui\input_transformation;
+use qtype_questionpy\question_ui\question_ui_transformation;
+use qtype_questionpy\question_ui\shuffle_transformation;
+use qtype_questionpy\question_ui\verbatim_transformation;
+use question_attempt;
+use question_display_options;
+
+/**
+ * Parses the question UI XML, transforms it, and renders it to HTML.
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class question_ui {
+    /** @var string XML namespace for XHTML */
+    public const XHTML_NAMESPACE = "http://www.w3.org/1999/xhtml";
+    /** @var string XML namespace for our custom things */
+    public const QPY_NAMESPACE = "http://questionpy.org/ns/question";
+
+    /** @var string[] class names of {@see question_ui_transformation}s to apply, in order */
+    private const TRANSFORMATIONS = [
+        feedback_transformation::class,
+        shuffle_transformation::class,
+        input_transformation::class,
+        verbatim_transformation::class,
+        cleanup_transformation::class
+    ];
+
+    /** @var DOMDocument $question */
+    public DOMDocument $question;
+
+    /** @var DOMXPath $xpath */
+    private DOMXPath $xpath;
+
+    /** @var question_metadata|null $metadata */
+    private ?question_metadata $metadata = null;
+
+    /**
+     * Parses the given XML and initializes a new {@see question_ui} instance.
+     *
+     * @param string $xml XML as returned by the QPy Server
+     */
+    public function __construct(string $xml) {
+        $this->question = new DOMDocument();
+        $this->question->loadXML($xml);
+        $this->question->normalizeDocument();
+
+        $this->xpath = new DOMXPath($this->question);
+        $this->xpath->registerNamespace("xhtml", self::XHTML_NAMESPACE);
+        $this->xpath->registerNamespace("qpy", self::QPY_NAMESPACE);
+    }
+
+    /**
+     * Renders the contents of the `qpy:formulation` element. Throws an exception if there is none.
+     *
+     * @param question_attempt $qa
+     * @param question_display_options $options
+     * @return string
+     * @throws coding_exception
+     */
+    public function render_formulation(question_attempt $qa, question_display_options $options): string {
+        $elements = $this->question->getElementsByTagNameNS(self::QPY_NAMESPACE, "formulation");
+        if ($elements->length < 1) {
+            // TODO: Helpful exception.
+            throw new coding_exception("Question UI XML contains no 'qpy:formulation' element");
+        }
+
+        return $this->render_part($elements->item(0), $qa, $options);
+    }
+
+    /**
+     * Renders the contents of the `qpy:general-feedback` element or returns null if there is none.
+     * @param question_attempt $qa
+     * @return string|null
+     */
+    public function render_general_feedback(question_attempt $qa): ?string {
+        $elements = $this->question->getElementsByTagNameNS(self::QPY_NAMESPACE, "general-feedback");
+        if ($elements->length < 1) {
+            return null;
+        }
+
+        return $this->render_part($elements->item(0), $qa);
+    }
+
+    /**
+     * Renders the contents of the `qpy:specific-feedback` element or returns null if there is none.
+     * @param question_attempt $qa
+     * @return string|null
+     */
+    public function render_specific_feedback(question_attempt $qa): ?string {
+        $elements = $this->question->getElementsByTagNameNS(self::QPY_NAMESPACE, "specific-feedback");
+        if ($elements->length < 1) {
+            return null;
+        }
+
+        return $this->render_part($elements->item(0), $qa);
+    }
+
+
+    /**
+     * Renders the contents of the `qpy:right-answer` element or returns null if there is none.
+     * @param question_attempt $qa
+     * @return string|null
+     */
+    public function render_right_answer(question_attempt $qa): ?string {
+        $elements = $this->question->getElementsByTagNameNS(self::QPY_NAMESPACE, "right-answer");
+        if ($elements->length < 1) {
+            return null;
+        }
+
+        return $this->render_part($elements->item(0), $qa);
+    }
+
+    /**
+     * Extracts metadata from the question UI.
+     *
+     * @return question_metadata
+     */
+    public function get_metadata(): question_metadata {
+        if (!$this->metadata) {
+            $this->metadata = new question_metadata();
+            /** @var DOMAttr $attr */
+            foreach ($this->xpath->query("/qpy:question/qpy:formulation//@qpy:correct-response") as $attr) {
+                $element = $attr->ownerElement;
+                $name = $element->getAttribute("name");
+                if (!$name) {
+                    continue;
+                }
+
+                if (is_null($this->metadata->correctresponse)) {
+                    $this->metadata->correctresponse = [];
+                }
+
+                if ($element->getAttribute("type") == "radio") {
+                    // On radio buttons, we expect the correct option to be marked with correct-response.
+                    $radiovalue = $element->getAttribute("value");
+                    $this->metadata->correctresponse[$name] = $radiovalue;
+                } else {
+                    $this->metadata->correctresponse[$name] = $attr->value;
+                }
+            }
+
+            /** @var DOMElement $element */
+            foreach ($this->xpath->query("/qpy:question/qpy:formulation//xhtml:input") as $element) {
+                $name = $element->getAttribute("name");
+                if ($name) {
+                    $this->metadata->expecteddata[$name] = PARAM_RAW;
+                }
+            }
+        }
+
+        return $this->metadata;
+    }
+
+    /**
+     * Applies transformations to the descendants of a given node and returns the resulting HTML.
+     *
+     * @param \DOMNode $part
+     * @param question_attempt $qa
+     * @param question_display_options|null $options
+     * @return string
+     */
+    private function render_part(\DOMNode $part, question_attempt $qa, ?question_display_options $options = null): string {
+        $newdoc = new DOMDocument();
+        foreach ($part->childNodes as $child) {
+            $newdoc->appendChild($newdoc->importNode($child, true));
+        }
+
+        $xpath = new DOMXPath($newdoc);
+        $xpath->registerNamespace("qpy", self::QPY_NAMESPACE);
+
+        foreach (self::TRANSFORMATIONS as $class) {
+            /** @var question_ui_transformation $transformation */
+            $transformation = new $class($xpath, $qa, $options);
+            $nodes = $transformation->collect();
+            foreach ($nodes as $node) {
+                $transformation->transform_node($node);
+            }
+        }
+
+        return $newdoc->saveHTML();
+    }
+}

--- a/classes/question_ui/cleanup_transformation.php
+++ b/classes/question_ui/cleanup_transformation.php
@@ -1,0 +1,58 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\question_ui;
+
+use DOMAttr;
+use DOMNode;
+use DOMNodeList;
+
+/**
+ * Removes remaining QuestionPy elements and attributes as well as comments.
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class cleanup_transformation extends question_ui_transformation {
+
+    /**
+     * Returns the nodes which this transformation should apply to.
+     *
+     * @return DOMNodeList
+     */
+    public function collect(): DOMNodeList {
+        return $this->xpath->query("//qpy:* | //@qpy:* | //comment()");
+    }
+
+    /**
+     * Transforms the given node in-place.
+     *
+     * The default implementation delegates to {@see transform_element()} or {@see transform_pi()}, depending on the
+     * node type.
+     *
+     * @param DOMNode $node one of the nodes returned by {@see collect()}
+     * @return void
+     */
+    public function transform_node(DOMNode $node): void {
+        if ($node instanceof DOMAttr) {
+            $node->parentNode->removeAttributeNode($node);
+        } else {
+            $node->parentNode->removeChild($node);
+        }
+    }
+}

--- a/classes/question_ui/feedback_transformation.php
+++ b/classes/question_ui/feedback_transformation.php
@@ -1,0 +1,56 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\question_ui;
+
+use DOMElement;
+use DOMNodeList;
+use qtype_questionpy\question_ui;
+
+/**
+ * Removes elements marked with `qpy:feedback` when the type of feedback is disabled in {@see \question_display_options}.
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class feedback_transformation extends question_ui_transformation {
+
+    /**
+     * Returns the nodes which this transformation should apply to.
+     *
+     * @return DOMNodeList
+     */
+    public function collect(): DOMNodeList {
+        return $this->xpath->query("//*[@qpy:feedback]");
+    }
+
+    /**
+     * Transforms the given element in-place. Delegated to by {@see transform_node()}.
+     *
+     * @param DOMElement $element
+     * @return void
+     */
+    protected function transform_element(DOMElement $element): void {
+        $feedback = $element->getAttributeNS(question_ui::QPY_NAMESPACE, "feedback");
+
+        if (($feedback == "general" && !$this->options->generalfeedback)
+            || ($feedback == "specific" && !$this->options->feedback)) {
+            $element->parentNode->removeChild($element);
+        }
+    }
+}

--- a/classes/question_ui/input_transformation.php
+++ b/classes/question_ui/input_transformation.php
@@ -1,0 +1,77 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\question_ui;
+
+use DOMElement;
+use DOMNodeList;
+
+/**
+ * Transforms HTML `input` elements.
+ *
+ * - The name is mangled using {@see \question_attempt::get_qt_field_name()}.
+ * - If a value was saved for the input in a previous step, the latest value is added to the HTML.
+ * - If {@see \question_display_options::$readonly} is set, the input is disabled.
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class input_transformation extends question_ui_transformation {
+
+    /**
+     * Returns the nodes which this transformation should apply to.
+     *
+     * @return DOMNodeList
+     */
+    public function collect(): DOMNodeList {
+        return $this->doc->getElementsByTagName("input");
+    }
+
+    /**
+     * Transforms the given element in-place. Delegated to by {@see transform_node()}.
+     *
+     * @param DOMElement $element
+     * @return void
+     */
+    protected function transform_element(DOMElement $element): void {
+        $name = $element->getAttribute("name");
+        if (!$name) {
+            return;
+        }
+
+        // Moodle expects question input names to be mangled to avoid collisions between the questions of a test.
+        $element->setAttribute("name", $this->qa->get_qt_field_name($name));
+
+        // Set the last saved value.
+        $type = $element->getAttribute("type") ?: "text";
+        $lastvalue = $this->qa->get_last_qt_var($name);
+
+        if (!is_null($lastvalue)) {
+            if ($element->getAttribute("value") === $lastvalue
+                && ($type === "checkbox" || $type === "radio")) {
+                $element->setAttribute("checked", "checked");
+            } else {
+                $element->setAttribute("value", $lastvalue);
+            }
+        }
+
+        if ($this->options && $this->options->readonly) {
+            $element->setAttribute("disabled", "disabled");
+        }
+    }
+}

--- a/classes/question_ui/question_ui_transformation.php
+++ b/classes/question_ui/question_ui_transformation.php
@@ -1,0 +1,104 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\question_ui;
+
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMNodeList;
+use DOMProcessingInstruction;
+use DOMXPath;
+use question_attempt;
+use question_display_options;
+
+/**
+ * Base class for Question UI transformations.
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+abstract class question_ui_transformation {
+
+    /** @var DOMDocument */
+    protected DOMDocument $doc;
+    /** @var DOMXPath */
+    protected DOMXPath $xpath;
+    /** @var question_attempt */
+    protected question_attempt $qa;
+    /** @var question_display_options|null */
+    protected ?question_display_options $options;
+
+    /**
+     * Initializes a new instance.
+     *
+     * @param DOMXPath $xpath an XPath context for the question document
+     * @param question_attempt $qa
+     * @param question_display_options|null $options
+     */
+    final public function __construct(DOMXPath $xpath, question_attempt $qa, ?question_display_options $options) {
+        $this->doc = $xpath->document;
+        $this->xpath = $xpath;
+        $this->qa = $qa;
+        $this->options = $options;
+    }
+
+    /**
+     * Returns the nodes which this transformation should apply to.
+     *
+     * @return DOMNodeList
+     */
+    abstract public function collect(): DOMNodeList;
+
+    /**
+     * Transforms the given node in-place.
+     *
+     * The default implementation delegates to {@see transform_element()} or {@see transform_pi()}, depending on the
+     * node type.
+     *
+     * @param DOMNode $node one of the nodes returned by {@see collect()}
+     * @return void
+     */
+    public function transform_node(DOMNode $node): void {
+        if ($node instanceof DOMElement) {
+            $this->transform_element($node);
+        } else if ($node instanceof DOMProcessingInstruction) {
+            $this->transform_pi($node);
+        }
+    }
+
+    /**
+     * Transforms the given element in-place. Delegated to by {@see transform_node()}.
+     *
+     * @param DOMElement $element
+     * @return void
+     */
+    protected function transform_element(DOMElement $element): void {
+        // Default no-op.
+    }
+
+    /**
+     * Transforms the given processing instruction in-place. Delegated to by {@see transform_node()}.
+     *
+     * @param DOMProcessingInstruction $pi
+     * @return void
+     */
+    protected function transform_pi(DOMProcessingInstruction $pi): void {
+        // Default no-op.
+    }
+}

--- a/classes/question_ui/shuffle_transformation.php
+++ b/classes/question_ui/shuffle_transformation.php
@@ -1,0 +1,119 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\question_ui;
+
+use coding_exception;
+use DOMElement;
+use DOMNode;
+use DOMNodeList;
+use qtype_questionpy\question_ui;
+
+/**
+ * Shuffles children of elements marked with `qpy:shuffle-contents`.
+ *
+ * Also replaces `qpy:shuffled-index` elements which are descendants of each child with the new index of the child.
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class shuffle_transformation extends question_ui_transformation {
+
+    /**
+     * Returns the nodes which this transformation should apply to.
+     *
+     * @return DOMNodeList
+     */
+    public function collect(): DOMNodeList {
+        return $this->xpath->query("//*[@qpy:shuffle-contents]");
+    }
+
+    /**
+     * Transforms the given element in-place. Delegated to by {@see transform_node()}.
+     *
+     * @param DOMElement $element
+     * @return void
+     * @throws coding_exception
+     */
+    protected function transform_element(DOMElement $element): void {
+        $element->removeAttributeNS(question_ui::QPY_NAMESPACE, "shuffle-contents");
+        $newelement = $element->cloneNode();
+
+        // We want to shuffle elements while leaving other nodes (such as text, spacing) where they are.
+
+        // Collect the elements and shuffle them.
+        $childelements = [];
+        foreach ($element->childNodes as $child) {
+            if ($child instanceof DOMElement) {
+                $childelements[] = $child;
+            }
+        }
+        shuffle($childelements);
+
+        // Iterate over children, replacing elements with random ones while copying everything else.
+        $i = 1;
+        while ($element->hasChildNodes()) {
+            $child = $element->firstChild;
+            if ($child instanceof DOMElement) {
+                $child = array_pop($childelements);
+                $newelement->appendChild($child);
+                $this->replace_index($child, $i++);
+            } else {
+                $newelement->appendChild($child);
+            }
+        }
+        $element->parentNode->replaceChild($newelement, $element);
+    }
+
+    /**
+     * Among the descendants of `$element`, finds `qpy:shuffled-index` elements and replaces them with `$index`.
+     *
+     * @param DOMNode $element
+     * @param int $index
+     * @throws coding_exception
+     */
+    private function replace_index(DOMNode $element, int $index): void {
+        $indexelements = $this->xpath->query(".//qpy:shuffled-index", $element);
+        /** @var DOMElement $indexelement */
+        foreach ($indexelements as $indexelement) {
+            $format = $indexelement->getAttribute("format") ?: "123";
+
+            switch ($format) {
+                default:
+                    // TODO: Warning?
+                case "123":
+                    $indexstr = strval($index);
+                    break;
+                case "abc":
+                    $indexstr = strtolower(\question_utils::int_to_letter($index));
+                    break;
+                case "ABC":
+                    $indexstr = \question_utils::int_to_letter($index);
+                    break;
+                case "iii":
+                    $indexstr = \question_utils::int_to_roman($index);
+                    break;
+                case "III":
+                    $indexstr = strtoupper(\question_utils::int_to_roman($index));
+                    break;
+            }
+
+            $indexelement->parentNode->replaceChild(new \DOMText($indexstr), $indexelement);
+        }
+    }
+}

--- a/classes/question_ui/verbatim_transformation.php
+++ b/classes/question_ui/verbatim_transformation.php
@@ -1,0 +1,53 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\question_ui;
+
+use DOMNodeList;
+use DOMProcessingInstruction;
+
+/**
+ * Replaces `<?v` processing instructions with their content.
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class verbatim_transformation extends question_ui_transformation {
+
+    /**
+     * Returns the nodes which this transformation should apply to.
+     *
+     * @return DOMNodeList
+     */
+    public function collect(): DOMNodeList {
+        return $this->xpath->query("//processing-instruction('v')");
+    }
+
+    /**
+     * Transforms the given processing instruction in-place. Delegated to by {@see transform_node()}.
+     *
+     * @param DOMProcessingInstruction $pi
+     * @return void
+     */
+    protected function transform_pi(DOMProcessingInstruction $pi): void {
+        $frag = $pi->ownerDocument->createDocumentFragment();
+        $frag->appendXML($pi->data);
+
+        $pi->parentNode->replaceChild($frag, $pi);
+    }
+}

--- a/multiple-choice.xhtml
+++ b/multiple-choice.xhtml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  - This file is part of the QuestionPy Moodle plugin - https://questionpy.org/
+  -
+  - Moodle is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU General Public License as published by
+  - the Free Software Foundation, either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - Moodle is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU General Public License for more details.
+  -
+  - You should have received a copy of the GNU General Public License
+  - along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<qpy:question xmlns="http://www.w3.org/1999/xhtml"
+              xmlns:qpy="http://questionpy.org/ns/question"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://questionpy.org/ns/question question.xsd">
+    <qpy:formulation>
+        <div><?v Welcher ist der zweite Buchstabe im deutschen Alphabet??></div>
+        <fieldset qpy:shuffle-contents="" style="display: flex; flex-direction: column">
+            <label>
+                <input type="radio" name="choice" value="A"/>
+                <qpy:shuffled-index format="ABC"/>. A
+                <span qpy:feedback="specific" style="margin-left: .5em; background: rgb(68, 43, 6)">A ist der erste Buchstabe im deutschen Alphabet.</span>
+            </label>
+            <label>
+                <input type="radio" name="choice" value="B" qpy:correct-response=""/>
+                <qpy:shuffled-index format="ABC"/>. B
+                <span qpy:feedback="specific" style="margin-left: .5em; background: rgb(68, 43, 6)">Richtig!</span>
+            </label>
+            <label>
+                <input type="radio" name="choice" value="C"/>
+                <qpy:shuffled-index format="ABC"/>. C
+                <span qpy:feedback="specific" style="margin-left: .5em; background: rgb(68, 43, 6)">C ist der dritte Buchstabe im deutschen Alphabet.</span>
+            </label>
+        </fieldset>
+    </qpy:formulation>
+    <qpy:specific-feedback>
+        <p>Specific feedback</p>
+    </qpy:specific-feedback>
+    <qpy:general-feedback>
+        <p>General feedback</p>
+    </qpy:general-feedback>
+    <qpy:right-answer>
+        <p>Right answer</p>
+    </qpy:right-answer>
+</qpy:question>

--- a/question.php
+++ b/question.php
@@ -22,6 +22,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use qtype_questionpy\question_ui;
+
 /**
  * Represents a QuestionPy question.
  *
@@ -30,6 +32,23 @@
  */
 class qtype_questionpy_question extends question_graded_automatically_with_countback {
 
+    /** @var question_ui|null $ui */
+    private ?question_ui $ui = null;
+
+    /**
+     * Fetches the question UI XML from the QPy Server, parses it into a {@see question_ui} instance and caches that.
+     *
+     * @return question_ui
+     */
+    public function get_question_ui(): question_ui {
+        if (!$this->ui) {
+            // TODO: Get XML from server.
+            $xml = file_get_contents(__DIR__ . "/simple.xhtml");
+            $this->ui = new question_ui($xml);
+        }
+        return $this->ui;
+    }
+
     /**
      * What data may be included in the form submission when a student submits
      * this question in its current state?
@@ -37,12 +56,12 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
      * This information is used in calls to optional_param. The parameter name
      * has {@see question_attempt::get_field_prefix()} automatically prepended.
      *
-     * @return array|string variable name => PARAM_... constant, or, as a special case
+     * @return array variable name => PARAM_... constant, or, as a special case
      *      that should only be used in unavoidable, the constant question_attempt::USE_RAW_DATA
      *      meaning take all the raw submitted data belonging to this question.
      */
-    public function get_expected_data() {
-        return null;
+    public function get_expected_data(): array {
+        return $this->get_question_ui()->get_metadata()->expecteddata;
     }
 
     /**
@@ -53,8 +72,8 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
      *
      * @return array|null parameter name => value.
      */
-    public function get_correct_response() {
-        return null;
+    public function get_correct_response(): ?array {
+        return $this->get_question_ui()->get_metadata()->correctresponse;
     }
 
     /**
@@ -63,7 +82,7 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
      * should move to the COMPLETE or INCOMPLETE state.
      *
      * @param array $response responses, as returned by
-     *      {@see question_attempt_step::get_qt_data()}.
+     *                        {@see question_attempt_step::get_qt_data()}.
      * @return bool whether this response is a complete answer to this question.
      */
     public function is_complete_response(array $response) {
@@ -76,10 +95,10 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
      * of responses can safely be discarded.
      *
      * @param array $prevresponse the responses previously recorded for this question,
-     *      as returned by {@see question_attempt_step::get_qt_data()}
-     * @param array $newresponse the new responses, in the same format.
+     *                            as returned by {@see question_attempt_step::get_qt_data()}
+     * @param array $newresponse  the new responses, in the same format.
      * @return bool whether the two sets of responses are the same - that is
-     *      whether the new set of responses can safely be discarded.
+     *                            whether the new set of responses can safely be discarded.
      */
     public function is_same_response(array $prevresponse, array $newresponse) {
         return false;
@@ -110,8 +129,9 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
      * Grade a response to the question, returning a fraction between
      * get_min_fraction() and get_max_fraction(), and the corresponding {@see question_state}
      * right, partial or wrong.
+     *
      * @param array $response responses, as returned by
-     *      {@see question_attempt_step::get_qt_data()}.
+     *                        {@see question_attempt_step::get_qt_data()}.
      * @return array (float, integer) the fraction, and the state.
      */
     public function grade_response(array $response) {
@@ -123,11 +143,11 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
      * tries the student made.
      *
      * @param array $responses the response for each try. Each element of this
-     * array is a response array, as would be passed to {@see grade_response()}.
-     * There may be between 1 and $totaltries responses.
-     * @param int $totaltries The maximum number of tries allowed.
+     *                         array is a response array, as would be passed to {@see grade_response()}.
+     *                         There may be between 1 and $totaltries responses.
+     * @param int $totaltries  The maximum number of tries allowed.
      * @return numeric the fraction that should be awarded for this
-     * sequence of response.
+     *                         sequence of response.
      */
     public function compute_final_grade($responses, $totaltries) {
         return 0;

--- a/question.xsd
+++ b/question.xsd
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+  ~ This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+  ~
+  ~ Moodle is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ Moodle is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<xs:schema xmlns="http://questionpy.org/ns/question"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xhtml="http://www.w3.org/1999/xhtml"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.w3.org/1999/xhtml https://www.w3.org/MarkUp/SCHEMA/xhtml11.xsd"
+           targetNamespace="http://questionpy.org/ns/question"
+           elementFormDefault="qualified">
+    <xs:import namespace="http://www.w3.org/1999/xhtml" schemaLocation="https://www.w3.org/MarkUp/SCHEMA/xhtml11.xsd"/>
+
+    <xs:element name="question">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="formulation">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:group ref="xhtml:xhtml.Flow.mix" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="specific-feedback">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:group ref="xhtml:xhtml.Flow.mix" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="general-feedback">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:group ref="xhtml:xhtml.Flow.mix" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="right-answer">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:group ref="xhtml:xhtml.Flow.mix" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:attribute name="correct-response" type="xs:string"/>
+    <xs:attribute name="shuffle-contents"/>
+    <xs:attribute name="feedback">
+        <xs:simpleType>
+            <xs:restriction base="xs:string">
+                <xs:enumeration value="general"/>
+                <xs:enumeration value="specific"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:attribute>
+
+    <xs:element name="shuffled-index">
+        <xs:complexType>
+            <xs:attribute name="format">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="123"/>
+                        <xs:enumeration value="abc"/>
+                        <xs:enumeration value="ABC"/>
+                        <xs:enumeration value="iii"/>
+                        <xs:enumeration value="III"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/renderer.php
+++ b/renderer.php
@@ -22,8 +22,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use qtype_questionpy\api\api;
-
 /**
  * Generates the output for QuestionPy questions.
  *
@@ -31,18 +29,34 @@ use qtype_questionpy\api\api;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class qtype_questionpy_renderer extends qtype_renderer {
+
     /**
      * Generate the display of the formulation part of the question. This is the
      * area that contains the quetsion text, and the controls for students to
      * input their answers. Some question types also embed bits of feedback, for
      * example ticks and crosses, in this area.
      *
-     * @param question_attempt $qa the question attempt to display.
+     * @param question_attempt $qa              the question attempt to display.
      * @param question_display_options $options controls what should and should not be displayed.
      * @return string HTML fragment.
+     * @throws coding_exception
      */
-    public function formulation_and_controls(question_attempt $qa, question_display_options $options) {
-        return '';
+    public function formulation_and_controls(question_attempt $qa, question_display_options $options): string {
+        $question = $qa->get_question(false);
+        assert($question instanceof qtype_questionpy_question);
+        return $question->get_question_ui()->render_formulation($qa, $options);
+    }
+
+    /**
+     * Generate the general feedback. This is feedback shown to all students.
+     *
+     * @param question_attempt $qa the question attempt to display.
+     * @return string HTML fragment.
+     */
+    protected function general_feedback(question_attempt $qa): string {
+        $question = $qa->get_question(false);
+        assert($question instanceof qtype_questionpy_question);
+        return $question->get_question_ui()->render_general_feedback($qa) ?? "";
     }
 
     /**
@@ -52,8 +66,10 @@ class qtype_questionpy_renderer extends qtype_renderer {
      * @param question_attempt $qa the question attempt to display.
      * @return string HTML fragment.
      */
-    public function specific_feedback(question_attempt $qa) {
-        return '';
+    public function specific_feedback(question_attempt $qa): string {
+        $question = $qa->get_question(false);
+        assert($question instanceof qtype_questionpy_question);
+        return $question->get_question_ui()->render_specific_feedback($qa) ?? "";
     }
 
     /**
@@ -64,8 +80,10 @@ class qtype_questionpy_renderer extends qtype_renderer {
      * @param question_attempt $qa the question attempt to display.
      * @return string HTML fragment.
      */
-    public function correct_response(question_attempt $qa) {
-        return '';
+    public function correct_response(question_attempt $qa): string {
+        $question = $qa->get_question(false);
+        assert($question instanceof qtype_questionpy_question);
+        return $question->get_question_ui()->render_right_answer($qa) ?? "";
     }
 
     /**

--- a/simple.xhtml
+++ b/simple.xhtml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  - This file is part of the QuestionPy Moodle plugin - https://questionpy.org/
+  -
+  - Moodle is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU General Public License as published by
+  - the Free Software Foundation, either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - Moodle is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU General Public License for more details.
+  -
+  - You should have received a copy of the GNU General Public License
+  - along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<qpy:question xmlns="http://www.w3.org/1999/xhtml"
+              xmlns:qpy="http://questionpy.org/ns/question"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://questionpy.org/ns/question question.xsd">
+    <qpy:formulation>
+        <div><?v Wieviele kantendisjunkte Spannbäume kann ein planarer Graph maximal haben??></div>
+        <label>
+            Antwort:
+            <input type="number" name="response" min="0" qpy:correct-response="2"/>
+        </label>
+    </qpy:formulation>
+    <qpy:general-feedback>
+        <p>Zu beweisen mithilfe der Euler'schen Polyederformel und |E| = |V| - 1 für alle Bäume T = (V, E).</p>
+    </qpy:general-feedback>
+    <qpy:right-answer>Die richtige Antwort ist: 2</qpy:right-answer>
+</qpy:question>


### PR DESCRIPTION
An bisher drei Stellen wird das Question-XML verwendet:
- `qtype_questionpy_renderer::formulation_and_controls`
- `qtype_questionpy_renderer::general_feedback`
- `qtype_questionpy_renderer::specific_feedback`
- `qtype_questionpy_renderer::correct_response`
- `qtype_questionpy_question::get_expected_data`
- `qtype_questionpy_question::get_correct_response`

Jeweils wird `qtype_questionpy_question::get_question_ui` aufgerufen, die einmal pro Frage (und Skript-Ausführung) das XML aus einer hartgecodeten Datei lädt (später dann vom Server), und eine `question_ui`-Instanz draus macht, wobei das XML mit PHP's DOM-Library geparst wird.

Wird ein Teil der Frage gerendert, lässt `question_ui` mehrere Transformationen darüber laufen, die in `classes/question_ui` liegen, und gibt das Ergebnis dann als HTML aus. Für `get_expected_data` und `get_correct_response` gibt es `question_ui::get_metadata`.

Ich habe zwei simple Beispiel-XMLs geschrieben, aktuell wird `simple.xhtml` verwendet. Ich habe auch ein XML Schema `question.xsd` geschrieben, das funktioniert aber wie erwähnt noch nicht 100%-ig.