### PR TITLE
fix: `get_records()` uses correct table

### DIFF
--- a/classes/external/load_packages.php
+++ b/classes/external/load_packages.php
@@ -22,7 +22,7 @@ use external_single_structure;
 use external_value;
 use moodle_exception;
 use qtype_questionpy\api\api;
-use qtype_questionpy\package\package;
+use qtype_questionpy\package\package_version;
 
 /**
  * This service loads QuestionPy packages from the application server into the database.
@@ -57,10 +57,10 @@ class load_packages extends external_api {
 
         $transaction = $DB->start_delegated_transaction();
 
-        // Remove every package that was received from the application server.
-        $packages = package::get_records(['userid' => null]);
-        foreach ($packages as $package) {
-            $package->delete();
+        // Remove every package version that was received from the application server.
+        $versions = package_version::get_records(['userid' => null]);
+        foreach ($versions as $version) {
+            $version->delete();
         }
 
         // Load packages from the application server.

--- a/classes/external/remove_packages.php
+++ b/classes/external/remove_packages.php
@@ -21,7 +21,7 @@ use external_function_parameters;
 use external_single_structure;
 use external_value;
 use moodle_exception;
-use qtype_questionpy\package\package;
+use qtype_questionpy\package\package_version;
 
 /**
  * This service removes packages from the database that were not uploaded by a trainer.
@@ -53,10 +53,10 @@ class remove_packages extends external_api {
 
         $transaction = $DB->start_delegated_transaction();
 
-        // Only delete packages that were not uploaded by a user.
-        $packages = package::get_records(['userid' => null]);
-        foreach ($packages as $package) {
-            $package->delete();
+        // Only delete package versions that were not uploaded by a user.
+        $versions = package_version::get_records(['userid' => null]);
+        foreach ($versions as $version) {
+            $version->delete();
         }
 
         $transaction->allow_commit();

--- a/classes/form/package_upload.php
+++ b/classes/form/package_upload.php
@@ -29,6 +29,7 @@ defined('MOODLE_INTERNAL') || die;
 use moodle_exception;
 use qtype_questionpy\localizer;
 use qtype_questionpy\package\package;
+use qtype_questionpy\package\package_version;
 
 require_once($CFG->libdir . "/formslib.php");
 
@@ -55,11 +56,11 @@ class package_upload extends \moodleform {
         $group = array();
 
         $languages = localizer::get_preferred_languages();
-        $packages = package::get_records(['contextid' => $contextid]);
+        $versions = package_version::get_records(['contextid' => $contextid]);
 
-        foreach ($packages as $package) {
+        foreach ($versions as $version) {
             // Get localized package texts.
-            $packagearray = $package->as_localized_array($languages);
+            $packagearray = package::get_by_version($version->id)->as_localized_array($languages);
 
             $group[] = $mform->createElement('text', 'questionpy_package_hash',
                 $OUTPUT->render_from_template('qtype_questionpy/package', $packagearray),

--- a/classes/package/package.php
+++ b/classes/package/package.php
@@ -101,12 +101,10 @@ class package extends package_base {
     public static function get_records(?array $conditions = null): array {
         global $DB;
         $packages = array();
-        $records = $DB->get_records('qtype_questionpy_pkgversion', $conditions);
+        $records = $DB->get_records('qtype_questionpy_package', $conditions);
         foreach ($records as $record) {
-            $package = self::get_package_data($record->packageid);
-            $package = array_merge((array) $record, (array) $package);
-
-            $packages[] = array_converter::from_array(self::class, $package);
+            $package = self::get_package_data($record->id);
+            $packages[] = array_converter::from_array(self::class, (array) $package);
         }
         return $packages;
     }

--- a/classes/package/package_version.php
+++ b/classes/package/package_version.php
@@ -77,6 +77,24 @@ class package_version {
     }
 
     /**
+     * Get packages from the db matching given conditions. Note: only conditions stored in the package version table
+     * are applicable.
+     *
+     * @param array|null $conditions
+     * @return package_version[]
+     * @throws moodle_exception
+     */
+    public static function get_records(?array $conditions = null): array {
+        global $DB;
+        $packages = array();
+        $records = $DB->get_records('qtype_questionpy_pkgversion', $conditions);
+        foreach ($records as $record) {
+            $packages[] = array_converter::from_array(self::class, (array) $record);
+        }
+        return $packages;
+    }
+
+    /**
      * Deletes the package version from the database.
      * If the package has only one version, the package related data is also deleted.
      *


### PR DESCRIPTION
Zuvor konnte mit `package::get_records(conditions)` nach Paketen in der `pkgversion`-Tabelle gefiltert werden. Nun hat jede Klasse (`package` und `package_version`) ihre eigene `get_records(conditions)`-Methode, die die korrekte Tabelle verwendet.