### PR TITLE
Placeholder Cleaning

### DIFF
--- a/tests/question_ui_renderer_test.php
+++ b/tests/question_ui_renderer_test.php
@@ -285,14 +285,17 @@ class question_ui_renderer_test extends \advanced_testcase {
         $qa = $this->createStub(\question_attempt::class);
 
         $ui = new question_ui_renderer($input, [
-            "param" => "Value of param <b>one</b>",
+            "param" => "Value of param <b>one</b>.<script>'Oh no, danger!'</script>",
         ], mt_rand());
 
         $result = $ui->render_formulation($qa, new \question_display_options());
 
         $this->assertXmlStringEqualsXmlString(<<<EXPECTED
         <div xmlns="http://www.w3.org/1999/xhtml">
-            <span>Parameter: Value of param <b>one</b></span>
+            <span>By default cleaned parameter: Value of param <b>one</b>.</span>
+            <span>Explicitly cleaned parameter: Value of param <b>one</b>.</span>
+            <span>Noclean parameter: Value of param <b>one</b>.<script>'Oh no, danger!'</script></span>
+            <span>Plain parameter: <![CDATA[Value of param <b>one</b>.<script>'Oh no, danger!'</script>]]></span>
         </div>
         EXPECTED, $result);
     }
@@ -315,7 +318,10 @@ class question_ui_renderer_test extends \advanced_testcase {
 
         $this->assertXmlStringEqualsXmlString(<<<EXPECTED
         <div xmlns="http://www.w3.org/1999/xhtml">
-            <span>Parameter: </span>
+            <span>By default cleaned parameter: </span>
+            <span>Explicitly cleaned parameter: </span>
+            <span>Noclean parameter: </span>
+            <span>Plain parameter: </span>
         </div>
         EXPECTED, $result);
     }

--- a/tests/question_uis/placeholder.xhtml
+++ b/tests/question_uis/placeholder.xhtml
@@ -1,5 +1,8 @@
 <qpy:question xmlns:qpy="http://questionpy.org/ns/question">
     <qpy:formulation>
-        <span>Parameter: <?p param?></span>
+        <span>By default cleaned parameter: <?p param?></span>
+        <span>Explicitly cleaned parameter: <?p param clean?></span>
+        <span>Noclean parameter: <?p param noclean?></span>
+        <span>Plain parameter: <?p param plain?></span>
     </qpy:formulation>
 </qpy:question>


### PR DESCRIPTION
`format_text` scheint noch andere Transformationen zu machen als nur gefährliche Tags zu entfernen. Ich habe jetzt zu `clean_text` gegriffen, was sonst auch aus `format_text` aufgerufen wird.

Wie der Rest des Uis werden auch die Platzhalter-Werte als **X**HTML interpretiert (wenn `clean` oder `noclean`). `<input>` statt `<input/>` würde zum Beispiel auch hier zu einem Fehler führen. `clean_text`  scheint auch XHTML zu unterstützen.