### PR TITLE
feat: package search endpoint

### DIFF
--- a/classes/external/search_packages.php
+++ b/classes/external/search_packages.php
@@ -1,0 +1,399 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\external;
+
+defined('MOODLE_INTERNAL') || die;
+
+global $CFG;
+require_once($CFG->libdir . "/externallib.php");
+
+use external_api;
+use external_function_parameters;
+use external_multiple_structure;
+use external_single_structure;
+use external_value;
+use invalid_parameter_exception;
+use moodle_exception;
+use qtype_questionpy\localizer;
+
+/**
+ * This service can be used to search and filter for packages in the database.
+ *
+ * @package    qtype_questionpy
+ * @copyright  2023 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class search_packages extends external_api {
+
+    /** @var string[] Valid categories. */
+    const CATEGORIES = ['all', 'lastused', 'favourites', 'mine'];
+    /** @var string[] Valid kinds of sorting. */
+    const SORT = ['alpha', 'date'];
+    /** @var string[] Valid sorting direction. */
+    const ORDER = ['asc', 'desc'];
+
+    /**
+     * Used to verify the parameters passed to the service.
+     *
+     * @return external_function_parameters
+     */
+    public static function execute_parameters(): external_function_parameters {
+        return new external_function_parameters([
+            'query' => new external_value(PARAM_RAW, 'Search query'),
+            'tags' => new external_multiple_structure(new external_value(PARAM_INT), 'Package tag ids'),
+            'category' => new external_value(PARAM_ALPHA),
+            'sort' => new external_value(PARAM_ALPHA),
+            'order' => new external_value(PARAM_ALPHA),
+            'limit' => new external_value(PARAM_INT),
+            'offset' => new external_value(PARAM_INT),
+        ]);
+    }
+
+    /**
+     * In addition to {@see self::validate_parameters} this method validates the values of the parameters and therefore
+     * should be called after {@see self::validate_parameters}.
+     *
+     * @param mixed $params The parameters.
+     * @return void
+     * @throws invalid_parameter_exception
+     */
+    private static function validate_parameter_values($params): void {
+        if (!in_array($params['category'], self::CATEGORIES)) {
+            $validparameters = implode(', ', self::CATEGORIES);
+            throw new invalid_parameter_exception("Unknown category. Valid parameters are: $validparameters");
+        }
+        if ($params['category'] !== 'all') {
+            // TODO: change if more categories are available.
+            throw new invalid_parameter_exception("Only the category 'all' is currently supported.");
+        }
+        if (!in_array($params['sort'], self::SORT)) {
+            $validparameters = implode(', ', self::SORT);
+            throw new invalid_parameter_exception("Unknown sort. Valid parameters are: $validparameters");
+        }
+        if (!in_array($params['order'], self::ORDER)) {
+            $validparameters = implode(', ', self::ORDER);
+            throw new invalid_parameter_exception("Unknown order. Valid parameters are: $validparameters");
+        }
+    }
+
+    /**
+     * Constructs sql fragment for performing safe text search on given fields.
+     *
+     * Creates a DNF.
+     *
+     * @param string[] $fieldnames The names of the table columns.
+     * @param string $query The query containing the words to be looked for.
+     * @return array A list containing the constructed sql fragment and an array of parameters.
+     */
+    private static function create_text_search_sql(array $fieldnames, string $query): array {
+        global $DB;
+
+        $query = trim($query);
+
+        if ($query == '' || strlen($query) == 1) {
+            return ['', []];
+        }
+
+        $segments = [];
+        $params = [];
+        $words = explode(' ', $query);
+
+        foreach ($words as $i => $word) {
+            $word = trim($word);
+            // Discard words of length 1.
+            if (strlen($word) <= 1) {
+                continue;
+            }
+
+            $escapedword = $DB->sql_like_escape($word);
+            foreach ($fieldnames as $j => $fieldname) {
+                // Create case-insensitive sql like fragment.
+                $param = "word{$i}field$j";
+                $params[$param] = '%' . $escapedword . '%';
+                $segments[$fieldname][] = $DB->sql_like($fieldname, ":$param", false);
+            }
+        }
+
+        $parts = [];
+        foreach ($fieldnames as $fieldname) {
+            $parts[] = '(' . implode(' AND ', $segments[$fieldname]) . ')';
+        }
+        $sql = implode(' OR ', $parts);
+        return [$sql, $params];
+    }
+
+    /**
+     * Retrieves the tags and package versions of multiple packages given their ids.
+     *
+     * @param int[] $ids Package ids.
+     * @return array[] A list containing the tags and versions.
+     * @throws moodle_exception
+     */
+    private static function get_tags_and_versions(array $ids): array {
+        global $DB, $USER;
+
+        if (empty($ids)) {
+            return [[], []];
+        }
+
+        // Create sql fragment and parameters.
+        [$insql, $inparams] = $DB->get_in_or_equal($ids);
+
+        // Get tags.
+        $tagsraw = $DB->get_records_sql("
+            SELECT id, packageid, tag
+            FROM {qtype_questionpy_tags}
+            WHERE packageid {$insql}
+        ", $inparams);
+
+        $tags = [];
+        foreach ($tagsraw as $tag) {
+            $tags[$tag->packageid][] = [
+                'id' => $tag->id,
+                'tag' => $tag->tag,
+            ];
+        }
+
+        // Get package versions.
+        $versionsraw = $DB->get_records_sql("
+            SELECT id, packageid, hash, version, userid
+            FROM {qtype_questionpy_pkgversion}
+            WHERE packageid {$insql}
+        ", $inparams);
+
+        $versions = [];
+        foreach ($versionsraw as $version) {
+            $versions[$version->packageid][] = [
+                'id' => $version->id,
+                'hash' => $version->hash,
+                'version' => $version->version,
+                'ismine' => $version->userid === $USER->id,
+            ];
+        }
+
+        return [$tags, $versions];
+    }
+
+    /**
+     * Constructs 'ORDER BY' sql fragment.
+     *
+     * @param string $sort Kind of ordering {@see search_packages::SORT}.
+     * @param string $order Direction of the ordering {@see search_packages::ORDER}.
+     * @return string The sql fragment.
+     */
+    private static function create_order_by_sql(string $sort, string $order): string {
+        $sql = 'ORDER BY';
+        if ($sort === 'alpha') {
+            $sql .= ' name';
+        } else {
+            $sql .= ' timecreated';
+        }
+        return $sql . ' ' . $order;
+    }
+
+    /**
+     * Constructs sql fragment for filtering by tags.
+     *
+     * TODO: change the logic when tags are localized.
+     *
+     * @param array $tags
+     * @return array A list containing the constructed sql fragment, the conditions and an array of parameters.
+     */
+    private static function create_tag_filter_sql(array $tags): array {
+        $joinsql = '';
+        $params = [];
+        $wheretags = [];
+        foreach ($tags as $i => $tag) {
+            $jointagsparam = "tag$i";
+            $params[$jointagsparam] = $tag;
+            $joinsql .= "
+                LEFT JOIN {qtype_questionpy_tags} t$i
+                ON t$i.packageid = p.id AND t$i.id = :$jointagsparam
+            ";
+            $wheretags[] = "NOT t$i IS NULL";
+        }
+        $wheresql = implode(' AND ', $wheretags);
+        return [$joinsql, $wheresql, $params];
+    }
+
+    /**
+     * Constructs sql fragment used to retrieve the best name and description translation.
+     *
+     * @return array A list containing the sql main fragment, parameter, coalesce sql fragment for name and description.
+     */
+    private static function create_best_language_sql(): array {
+        $languages = localizer::get_preferred_languages();
+
+        $joinlangssql = '';
+        $joinlangsparams = [];
+
+        $coalescename = [];
+        $coalescedesc = [];
+        foreach ($languages as $i => $language) {
+            $joinparam = "language$i";
+            $joinlangsparams[$joinparam] = $language;
+            $joinlangssql .= "
+                LEFT JOIN {qtype_questionpy_language} l$i
+                ON l$i.packageid = p.id AND l$i.language = :$joinparam
+            ";
+            $coalescename[] = "l$i.name";
+            $coalescedesc[] = "l$i.description";
+        }
+        $coalescenamesql = 'COALESCE(' . implode(',', $coalescename) . ')';
+        $coalescedescsql = 'COALESCE(' . implode(',', $coalescedesc) . ')';
+
+        return [$joinlangssql, $joinlangsparams, $coalescenamesql, $coalescedescsql];
+    }
+
+    /**
+     * Returns a valid WHERE-clause if a condition is given else ''.
+     *
+     * @param string $condition
+     * @return string
+     */
+    private static function sql_where(string $condition): string {
+        if (trim($condition) === '') {
+            return '';
+        }
+        return "WHERE $condition";
+    }
+
+    /**
+     * This method is called when the service is executed.
+     *
+     * @param string $query
+     * @param array $tags
+     * @param string $category
+     * @param string $sort
+     * @param string $order
+     * @param int $limit
+     * @param int $offset
+     * @return array
+     * @throws moodle_exception
+     */
+    public static function execute(string $query, array $tags, string $category, string $sort, string $order,
+                                   int $limit, int $offset): array {
+        global $DB;
+
+        // Basic parameter validation.
+        $params = self::validate_parameters(self::execute_parameters(), [
+            'query' => $query,
+            'tags' => $tags,
+            'category' => $category,
+            'sort' => $sort,
+            'order' => $order,
+            'limit' => $limit,
+            'offset' => $offset,
+        ]);
+
+        // In addition to the basic parameter validation we also want to validate the values.
+        self::validate_parameter_values($params);
+
+        // Create the 'ORDER BY' sql fragment.
+        $orderbysql = self::create_order_by_sql($params['sort'], $params['order']);
+
+        // Search only in best package translation.
+        [$joinlangssql, $joinlangsparams, $coalescenamesql, $coalescedescsql] = self::create_best_language_sql();
+
+        // Get only packages with specified tags.
+        [$jointagssql, $conditionssql, $jointagsparams] = self::create_tag_filter_sql($params['tags']);
+        $wheretagsql = self::sql_where($conditionssql);
+
+        // Prepare query.
+        [$likesql, $likeparams] = self::create_text_search_sql(['name', 'description'], $params['query']);
+        $wherelikesql = self::sql_where($likesql);
+
+        // Assemble the final sql.
+        // TODO: assemble the sql in a separate function and take the categories into account.
+        $finalsql = "
+            SELECT id, short_name, namespace, author, url, icon, license, name, description
+            FROM (
+                SELECT p.id, p.shortname AS short_name, p.namespace, p.author, p.url, p.icon, p.license,
+                       $coalescenamesql AS name, $coalescedescsql AS description, p.timecreated
+                FROM {qtype_questionpy_package} p
+                $joinlangssql
+                $jointagssql
+                $wheretagsql
+            ) subq
+            $wherelikesql
+            $orderbysql
+        ";
+
+        // Merge every parameter array.
+        $finalparams = array_merge($joinlangsparams, $jointagsparams, $likeparams);
+
+        // Execute the assembled sql query and set the limit and offset.
+        $packagesraw = $DB->get_records_sql($finalsql, $finalparams, $params['limit'] * $params['offset'], $params['limit']);
+
+        // Get package tag and versions.
+        $ids = array_column($packagesraw, 'id');
+        [$tags, $versions] = self::get_tags_and_versions($ids);
+
+        // Set the tags and package versions.
+        foreach ($packagesraw as $package) {
+            $package->tags = $tags[$package->id] ?? [];
+            // There should always be at least one version of a package therefore this check is obsolete.
+            $package->versions = $versions[$package->id] ?? [];
+            // TODO: Favourites API.
+            $package->isfavourite = false;
+        }
+
+        // Calculate total packages (without pagination).
+        $totalpackagessql = "
+            SELECT COUNT('x')
+            FROM ($finalsql) subqcount
+        ";
+        $totalpackagessql = $DB->count_records_sql($totalpackagessql, $finalparams);
+
+        return ['packages' => array_values($packagesraw), 'count' => count($packagesraw), 'total' => $totalpackagessql];
+    }
+
+
+    /**
+     * This method is used to specify the return value of the service.
+     *
+     * @return external_single_structure
+     */
+    public static function execute_returns(): external_single_structure {
+        return new external_single_structure([
+            'packages' => new external_multiple_structure(new external_single_structure([
+                'id' => new external_value(PARAM_INT),
+                'short_name' => new external_value(PARAM_ALPHANUMEXT),
+                'namespace' => new external_value(PARAM_ALPHANUMEXT),
+                'versions' => new external_multiple_structure(new external_single_structure([
+                    'id' => new external_value(PARAM_INT),
+                    'hash' => new external_value(PARAM_ALPHANUM),
+                    'version' => new external_value(PARAM_TEXT),
+                    'ismine' => new external_value(PARAM_BOOL),
+                ])),
+                'author' => new external_value(PARAM_RAW),
+                'name' => new external_value(PARAM_TEXT),
+                'url' => new external_value(PARAM_URL, '', VALUE_OPTIONAL),
+                'description' => new external_value(PARAM_RAW, '', VALUE_OPTIONAL),
+                'icon' => new external_value(PARAM_URL, '', VALUE_OPTIONAL),
+                'license' => new external_value(PARAM_TEXT),
+                'tags' => new external_multiple_structure(new external_single_structure([
+                    'id' => new external_value(PARAM_INT),
+                    'tag' => new external_value(PARAM_ALPHANUMEXT),
+                ])),
+                'isfavourite' => new external_value(PARAM_BOOL),
+            ])),
+            'count' => new external_value(PARAM_INT),
+            'total' => new external_value(PARAM_INT),
+        ]);
+    }
+}

--- a/classes/localizer.php
+++ b/classes/localizer.php
@@ -39,8 +39,11 @@ class localizer {
             $languages[] = $language;
         } while ($language = get_parent_language($language));
 
-        // Fallback is english - could be already inside the array, but that is okay.
-        $languages[] = 'en';
+        // Fallback is english.
+        if (!in_array('en', $languages)) {
+            $languages[] = 'en';
+        }
+
         return $languages;
     }
 }

--- a/db/services.php
+++ b/db/services.php
@@ -39,4 +39,11 @@ $functions = [
         'ajax' => true,
         'loginrequired' => true,
     ],
+    'qtype_questionpy_search_packages' => [
+        'classname' => 'qtype_questionpy\external\search_packages',
+        'description' => 'Search and filter for packages in the database.',
+        'type' => 'read',
+        'ajax' => true,
+        'loginrequired' => true,
+    ],
 ];

--- a/tests/data_provider.php
+++ b/tests/data_provider.php
@@ -47,6 +47,8 @@ use qtype_questionpy\package\package_raw;
 /**
  * Returns a raw package object which can be modified by an array of attributes.
  *
+ * The languages array gets generated when it is not set inside {@see $attributes}.
+ *
  * @param array $attributes
  * @return package_raw
  * @throws moodle_exception
@@ -56,30 +58,32 @@ function package_provider(array $attributes = []): package_raw {
         'short_name' => 'my_short_name',
         'namespace' => 'my_namespace',
         'name' => [
-            'en' => 'de: My Name',
-            'de' => 'en: My Name',
+            'en' => 'en: My Name',
+            'de' => 'de: My Name',
         ],
         'version' => '0.1.0',
         'type' => 'questiontype',
         'author' => 'John Doe',
         'url' => 'http://www.example.com/',
-        'languages' => [
-            0 => 'en',
-            1 => 'de',
-        ],
+        'languages' => ['en', 'de'],
         'description' => [
             'en' => 'en: Lorem ipsum dolor sit amet.',
             'de' => 'de: Lorem ipsum dolor sit amet.',
         ],
         'icon' => 'https://placehold.jp/40e47e/598311/150x150.png',
         'license' => 'MIT',
-        'tags' => [
-            0 => 'my_tag_0',
-            1 => 'my_tag_1',
-            2 => 'my_tag_2',
-        ],
+        'tags' => ['my_tag_0', 'my_tag_1', 'my_tag_2'],
     ], $attributes);
 
+    // Create 'languages' array based on provided 'name' and 'description' translations if none is provided.
+    if ((isset($attributes['name']) || isset($attributes['description'])) && !isset($attributes['languages'])) {
+        foreach (['name', 'description'] as $field) {
+            $data['languages'] = array_merge($data['languages'], array_keys($data[$field]));
+        }
+        $data['languages'] = array_values(array_unique($data['languages']));
+    }
+
+    // Calculate package hash if none is provided.
     if (!isset($attributes['package_hash'])) {
         $data['package_hash'] = hash('sha256', $data['short_name'] . $data['namespace'] . $data['version']);
     }

--- a/tests/external/search_packages_test.php
+++ b/tests/external/search_packages_test.php
@@ -107,6 +107,63 @@ class search_packages_test extends \externallib_advanced_testcase {
     }
 
     /**
+     * Provides invalid limits.
+     *
+     * @return array[]
+     */
+    public static function invalid_limit_provider(): array {
+        return [
+            [PHP_INT_MIN],
+            [-1],
+            [0],
+            [101],
+            [PHP_INT_MAX],
+        ];
+    }
+
+    /**
+     * Test the service with invalid limit parameters.
+     *
+     * @param int $limit
+     * @covers \qtype_questionpy\external\search_packages::execute
+     * @dataProvider invalid_limit_provider
+     * @throws moodle_exception
+     */
+    public function test_with_invalid_limit(int $limit): void {
+        $this->resetAfterTest();
+        $this->expectException(\invalid_parameter_exception::class);
+        $this->expectExceptionMessageMatches("/.*1 to 100.*/");
+        search_packages::execute('Test query', [], 'all', 'alpha', 'asc', $limit, 5);
+    }
+
+    /**
+     * Provides invalid page values.
+     *
+     * @return array[]
+     */
+    public static function invalid_page_value_provider(): array {
+        return [
+            [PHP_INT_MIN],
+            [-1],
+        ];
+    }
+
+    /**
+     * Test the service with invalid limit parameters.
+     *
+     * @param int $page
+     * @covers \qtype_questionpy\external\search_packages::execute
+     * @dataProvider invalid_page_value_provider
+     * @throws moodle_exception
+     */
+    public function test_with_invalid_page_value(int $page): void {
+        $this->resetAfterTest();
+        $this->expectException(\invalid_parameter_exception::class);
+        $this->expectExceptionMessageMatches("/.*can not be negative.*/");
+        search_packages::execute('Test query', [], 'all', 'alpha', 'asc', 1, $page);
+    }
+
+    /**
      * Provides valid but unsupported categories.
      *
      * @return array
@@ -397,15 +454,18 @@ class search_packages_test extends \externallib_advanced_testcase {
         // Sort the array of names so that we can use it as a reference.
         sort($names, SORT_STRING);
 
+        // The smallest valid limit is one.
+        $limit = max($totalpackages, 1);
+
         // Execute service with ascending order.
-        $res = search_packages::execute('', [], 'all', 'alpha', 'asc', $totalpackages, 0);
+        $res = search_packages::execute('', [], 'all', 'alpha', 'asc', $limit, 0);
         $res = external_api::clean_returnvalue(search_packages::execute_returns(), $res);
 
         $actualnamespaces = array_column($res['packages'], 'name');
         $this->assertEquals($names, $actualnamespaces);
 
         // Execute service with descending order.
-        $res = search_packages::execute('', [], 'all', 'alpha', 'desc', $totalpackages, 0);
+        $res = search_packages::execute('', [], 'all', 'alpha', 'desc', $limit, 0);
         $res = external_api::clean_returnvalue(search_packages::execute_returns(), $res);
 
         $actualnamespaces = array_column($res['packages'], 'name');

--- a/tests/external/search_packages_test.php
+++ b/tests/external/search_packages_test.php
@@ -1,0 +1,510 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for the search_packages function.
+ *
+ * @package    qtype_questionpy
+ * @copyright  2023 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later */
+
+namespace qtype_questionpy\external;
+
+use external_api;
+use moodle_exception;
+use function qtype_questionpy\package_provider;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(dirname(__DIR__) . '/data_provider.php');
+
+global $CFG;
+require_once($CFG->dirroot . '/webservice/tests/helpers.php');
+
+/**
+ * Tests for {@see search_packages}.
+ *
+ * @runTestsInSeparateProcesses
+ *
+ * @package    qtype_questionpy
+ * @author     Jan Britz
+ * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class search_packages_test extends \externallib_advanced_testcase {
+
+    /**
+     * Asserts that count and total are set correctly.
+     *
+     * @param array $result
+     * @param int $count
+     * @param int $total
+     * @return void
+     */
+    private function assert_count_and_total(array $result, int $count, int $total): void {
+        // Check if correct values are set.
+        $this->assertEquals($count, $result['count']);
+        $this->assertEquals($total, $result['total']);
+
+        // Check if the amount of packages is equal to $count.
+        $this->assertCount($count, $result['packages']);
+    }
+
+
+    /**
+     * Test the service with invalid category parameter.
+     *
+     * @covers \qtype_questionpy\external\search_packages::execute
+     * @throws moodle_exception
+     */
+    public function test_with_invalid_category_value() {
+        $this->resetAfterTest();
+        $this->expectException(\invalid_parameter_exception::class);
+        $expected = implode(', ', search_packages::CATEGORIES);
+        $this->expectExceptionMessageMatches("/.*$expected.*/i");
+        search_packages::execute('Test query', [], 'allmine', 'desc', 'date', 3, 5);
+    }
+
+    /**
+     * Test the service with invalid category parameter.
+     *
+     * @covers \qtype_questionpy\external\search_packages::execute
+     * @throws moodle_exception
+     */
+    public function test_with_invalid_sort_value() {
+        $this->resetAfterTest();
+        $this->expectException(\invalid_parameter_exception::class);
+        $expected = implode(', ', search_packages::SORT);
+        $this->expectExceptionMessageMatches("/.*$expected.*/i");
+        search_packages::execute('Test query', [], 'all', 'alphabetically', 'desc', 3, 5);
+    }
+
+    /**
+     * Test the service with invalid order parameter.
+     *
+     * @covers \qtype_questionpy\external\search_packages::execute
+     * @throws moodle_exception
+     */
+    public function test_with_invalid_order_value(): void {
+        $this->resetAfterTest();
+        $this->expectException(\invalid_parameter_exception::class);
+        $expected = implode(', ', search_packages::ORDER);
+        $this->expectExceptionMessageMatches("/.*$expected.*/i");
+        search_packages::execute('Test query', [], 'all', 'alpha', 'recentlyused', 3, 5);
+    }
+
+    /**
+     * Provides valid but unsupported categories.
+     *
+     * @return array
+     */
+    public static function category_provider(): array {
+        $parameters = [];
+        foreach (['lastused', 'favourites', 'mine'] as $category) {
+            $parameters[] = [$category];
+        }
+        return $parameters;
+    }
+
+    /**
+     * Tests that the service throws an error for valid but unsupported categories.
+     *
+     * @param string $category
+     * @covers \qtype_questionpy\external\search_packages::execute
+     * @dataProvider category_provider
+     * @return void
+     * @throws moodle_exception
+     */
+    public function test_categories(string $category): void {
+        $this->resetAfterTest();
+        $this->expectException(\invalid_parameter_exception::class);
+        search_packages::execute('Test query', [], $category, 'alpha', 'recentlyused', 3, 5);
+    }
+
+    /**
+     * Tests the service without available packages.
+     *
+     * @covers \qtype_questionpy\external\search_packages::execute
+     * @throws moodle_exception
+     */
+    public function test_search_without_filter_returns_every_package(): void {
+        $this->resetAfterTest();
+
+        // Execute service.
+        $res = search_packages::execute('', [], 'all', 'alpha', 'asc', 1, 0);
+        $res = external_api::clean_returnvalue(search_packages::execute_returns(), $res);
+
+        $this->assertEqualsCanonicalizing([
+            'packages' => [],
+            'count' => 0,
+            'total' => 0,
+        ], $res);
+    }
+
+    /**
+     * Tests that the service returns every version of a package.
+     *
+     * @covers \qtype_questionpy\external\search_packages::execute
+     * @throws moodle_exception
+     */
+    public function test_search_respects_package_versions(): void {
+        $this->resetAfterTest();
+
+        // Create packages and their versions.
+        $totalpackages = 2;
+        $totalversions = 3;
+
+        $versions = [];
+        for ($i = 0; $i < $totalpackages; $i++) {
+            $namespace = "n$i";
+            for ($j = 0; $j < $totalversions; $j++) {
+                $versionid = package_provider(['namespace' => $namespace, 'version' => "0.$j.0"])->store();
+                $versions[$namespace][] = $versionid;
+            }
+        }
+
+        // Execute service.
+        $res = search_packages::execute('', [], 'all', 'alpha', 'asc', $totalpackages, 0);
+        $res = external_api::clean_returnvalue(search_packages::execute_returns(), $res);
+
+        // Check if every version in DB is returned under the correct package.
+        $this->assertCount($totalpackages, $res['packages']);
+        foreach ($res['packages'] as $package) {
+            $this->assertCount($totalversions, $package['versions']);
+            foreach ($package['versions'] as $version) {
+                $this->assertContains($version['id'], $versions[$package['namespace']]);
+            }
+        }
+
+        // The amount of package versions should not change the package count.
+        $this->assert_count_and_total($res, $totalpackages, $totalpackages);
+    }
+
+    /**
+     * Acts as a provider for {@see test_query}.
+     *
+     * The arguments have the following format:
+     * - query
+     * - language - to be set for the user
+     * - packages - seperated by namespace; containing name and description translations
+     * - expected - list of expected packages (namespaces) and the keys of the expected translations [name, description]
+     *
+     * @return array[]
+     */
+    public static function query_provider(): array {
+        return [
+            // Query without any text.
+            ['', null, [
+                'ns1' => [['en' => 'en: x'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: x']],
+            ], ['ns1' => ['en', null], 'ns2' => ['en', 'en']]],
+            // Query without match.
+            ['match', null, [
+                'ns1' => [['en' => 'en: x'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: x']],
+            ], []],
+            // Query which matches the text.
+            ['en: match', null, [
+                'ns1' => [['en' => 'en: match'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: match']],
+                'ns3' => [['en' => 'en: match'], ['en' => 'en: match']],
+            ], ['ns1' => ['en', null], 'ns2' => ['en', 'en'], 'ns3' => ['en', 'en']]],
+            // Query with whole word.
+            ['match', null, [
+                'ns1' => [['en' => 'en: match'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: match']],
+                'ns3' => [['en' => 'en: match'], ['en' => 'en: match']],
+            ], ['ns1' => ['en', null], 'ns2' => ['en', 'en'], 'ns3' => ['en', 'en']]],
+            // Query with part of word.
+            ['atc', null, [
+                'ns1' => [['en' => 'en: match'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: match']],
+                'ns3' => [['en' => 'en: match'], ['en' => 'en: match']],
+            ], ['ns1' => ['en', null], 'ns2' => ['en', 'en'], 'ns3' => ['en', 'en']]],
+            // Query with different case - query uppercase / text lowercase.
+            ['MATCH', null, [
+                'ns1' => [['en' => 'en: match'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: match']],
+                'ns3' => [['en' => 'en: match'], ['en' => 'en: match']],
+            ], ['ns1' => ['en', null], 'ns2' => ['en', 'en'], 'ns3' => ['en', 'en']]],
+            // Query with different case - query lowercase / text uppercase.
+            ['match', null, [
+                'ns1' => [['en' => 'en: MATCH'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: MATCH']],
+                'ns3' => [['en' => 'en: MATCH'], ['en' => 'en: MATCH']],
+            ], ['ns1' => ['en', null], 'ns2' => ['en', 'en'], 'ns3' => ['en', 'en']]],
+            // Query with special characters.
+            ['!"§$%&/()=?', null, [
+                'ns1' => [['en' => 'en: !"§$%&/()=?'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: !"§$%&/()=?']],
+                'ns3' => [['en' => 'en: !"§$%&/()=?'], ['en' => 'en: !"§$%&/()=?']],
+            ], ['ns1' => ['en', null], 'ns2' => ['en', 'en'], 'ns3' => ['en', 'en']]],
+            // Query with whitespace.
+            [" \n\tmatch\n\t ", null, [
+                'ns1' => [['en' => 'en: match'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: match']],
+                'ns3' => [['en' => 'en: match'], ['en' => 'en: match']],
+            ], ['ns1' => ['en', null], 'ns2' => ['en', 'en'], 'ns3' => ['en', 'en']]],
+            // Match in fallback language while preferred language does not exist.
+            ['match', 'de', [
+                'ns1' => [['en' => 'en: match'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: match']],
+                'ns3' => [['en' => 'en: match'], ['en' => 'en: match']]
+            ], ['ns1' => ['en', null], 'ns2' => ['en', 'en'], 'ns3' => ['en', 'en']]],
+            // Match in fallback language while preferred language does exist but with no match.
+            ['match', 'de', [
+                'ns1' => [['en' => 'en: match', 'de' => 'de: x'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: match', 'de' => 'de: x']],
+                'ns3' => [['en' => 'en: match', 'de' => 'de: x'], ['en' => 'en: match', 'de' => 'de: x']]
+            ], []],
+            // Match in fallback language and preferred language.
+            ['match', 'de', [
+                'ns1' => [['en' => 'en: match', 'de' => 'de: match'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: match', 'de' => 'de: match']],
+                'ns3' => [['en' => 'en: match', 'de' => 'de: match'], ['en' => 'en: match', 'de' => 'de: match']]
+            ], ['ns1' => ['de', null], 'ns2' => ['en', 'de'], 'ns3' => ['de', 'de']]],
+            // Match in fallback language and preferred language.
+            ['match', 'de', [
+                'ns1' => [['en' => 'en: match', 'de' => 'de: match'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: match', 'de' => 'de: match']],
+                'ns3' => [['en' => 'en: match', 'de' => 'de: match'], ['en' => 'en: match', 'de' => 'de: match']]
+            ], ['ns1' => ['de', null], 'ns2' => ['en', 'de'], 'ns3' => ['de', 'de']]],
+            // Results must contain every word.
+            ['cool match', null, [
+                'ns1' => [['en' => 'en: match'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: match']],
+                'ns3' => [['en' => 'en: match'], ['en' => 'en: match']],
+            ], []],
+            ['cool match', null, [
+                'ns1' => [['en' => 'en: cool match'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: cool match']],
+                'ns3' => [['en' => 'en: cool match'], ['en' => 'en: cool match']],
+            ], ['ns1' => ['en', null], 'ns2' => ['en', 'en'], 'ns3' => ['en', 'en']]],
+            // The order of the words should not matter.
+            ['cool match', null, [
+                'ns1' => [['en' => 'en: this match is cool'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: this match is cool']],
+                'ns3' => [['en' => 'en: this match is cool'], ['en' => 'en: this match is cool']],
+            ], ['ns1' => ['en', null], 'ns2' => ['en', 'en'], 'ns3' => ['en', 'en']]],
+            // Ignore words with one character.
+            ['! match ?', null, [
+                'ns1' => [['en' => 'en: match'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: match']],
+                'ns3' => [['en' => 'en: match'], ['en' => 'en: match']],
+            ], ['ns1' => ['en', null], 'ns2' => ['en', 'en'], 'ns3' => ['en', 'en']]],
+            // Ignore words with one character.
+            ['a', null, [
+                'ns1' => [['en' => 'en: match'], []],
+                'ns2' => [['en' => 'en: x'], ['en' => 'en: match']],
+                'ns3' => [['en' => 'en: match'], ['en' => 'en: match']],
+            ], ['ns1' => ['en', null], 'ns2' => ['en', 'en'], 'ns3' => ['en', 'en']]],
+            // TODO: test for sql injection.
+            // TODO: test with parent and child language.
+        ];
+    }
+
+    /**
+     * Tests the service with different queries and languages.
+     *
+     * @param string $query
+     * @param string|null $language
+     * @param array $packages
+     * @param array $expected
+     * @covers \qtype_questionpy\external\search_packages::execute
+     * @dataProvider query_provider
+     * @return void
+     * @throws moodle_exception
+     */
+    public function test_query(string $query, ?string $language, array $packages, array $expected): void {
+        $this->resetAfterTest();
+
+        // Store every package in the database.
+        foreach ($packages as $namespace => [$names, $description]) {
+            package_provider(['namespace' => $namespace, 'name' => $names, 'description' => $description])->store();
+        }
+
+        // Set current language if provided.
+        if ($language) {
+            set_config('lang', $language);
+        }
+
+        // Execute the service.
+        $res = search_packages::execute($query, [], 'all', 'alpha', 'asc', count($packages), 0);
+        $res = external_api::clean_returnvalue(search_packages::execute_returns(), $res);
+
+        // Get every returned namespace and check if it is correct.
+        $actualnamespaces = array_column($res['packages'], 'namespace');
+        $this->assertEqualsCanonicalizing(array_keys($expected), $actualnamespaces);
+
+        // Check each returned name and description.
+        foreach ($res['packages'] as $package) {
+            $namespace = $package['namespace'];
+            [$namekey, $descriptionkey] = $expected[$namespace];
+            [$names, $descriptions] = $packages[$namespace];
+
+            $this->assertEquals($names[$namekey], $package['name']);
+            $this->assertEquals($descriptions[$descriptionkey] ?? '', $package['description']);
+        }
+
+        $totalpackages = count($expected);
+        $this->assert_count_and_total($res, $totalpackages, $totalpackages);
+    }
+
+    /**
+     * Provides valid package names for.
+     *
+     * @return array[][]
+     */
+    public static function names_provider(): array {
+        return [
+            [[]], // No name.
+            [['a']], // Only one name.
+            [['a', 'b', 'c', 'd']], // Ordered list of characters.
+            [['b', 'c', 'z', 'a']], // Unordered list of characters.
+            [['a1a', 'a2a', 'b1a', 'a2b', 'b11']], // Mixed list.
+        ];
+    }
+
+    /**
+     * Tests the alpha-sorting of the service.
+     *
+     * @param array $names
+     * @dataProvider names_provider
+     * @covers \qtype_questionpy\external\search_packages::execute
+     * @throws moodle_exception
+     */
+    public function test_alphabetical_sort(array $names): void {
+        $this->resetAfterTest();
+
+        $totalpackages = count($names);
+        foreach ($names as $name) {
+            package_provider(['namespace' => "ns$name", 'name' => ['en' => $name]])->store();
+        }
+
+        // Sort the array of names so that we can use it as a reference.
+        sort($names, SORT_STRING);
+
+        // Execute service with ascending order.
+        $res = search_packages::execute('', [], 'all', 'alpha', 'asc', $totalpackages, 0);
+        $res = external_api::clean_returnvalue(search_packages::execute_returns(), $res);
+
+        $actualnamespaces = array_column($res['packages'], 'name');
+        $this->assertEquals($names, $actualnamespaces);
+
+        // Execute service with descending order.
+        $res = search_packages::execute('', [], 'all', 'alpha', 'desc', $totalpackages, 0);
+        $res = external_api::clean_returnvalue(search_packages::execute_returns(), $res);
+
+        $actualnamespaces = array_column($res['packages'], 'name');
+        $this->assertEquals(array_reverse($names), $actualnamespaces);
+
+        $this->assert_count_and_total($res, $totalpackages, $totalpackages);
+    }
+
+    /**
+     * Tests the date-sorting of the service.
+     *
+     * @covers \qtype_questionpy\external\search_packages::execute
+     * @throws moodle_exception
+     */
+    public function test_date_sort(): void {
+        $this->resetAfterTest();
+
+        // Create multiple packages with different creation times.
+        $totalpackages = 3;
+
+        $namespaces = [];
+        for ($i = 0; $i < $totalpackages; $i++) {
+            $namespaces[] = "ns$i";
+            package_provider(['namespace' => "ns$i"])->store();
+            $this->waitForSecond();
+        }
+
+        // Execute service with ascending order.
+        $res = search_packages::execute('', [], 'all', 'date', 'asc', $totalpackages, 0);
+        $res = external_api::clean_returnvalue(search_packages::execute_returns(), $res);
+
+        // Check that package order is correct.
+        $actualnamespaces = array_column($res['packages'], 'namespace');
+        $this->assertEquals($namespaces, $actualnamespaces);
+
+        // Execute service with descending order.
+        $res = search_packages::execute('', [], 'all', 'date', 'desc', $totalpackages, 0);
+        $res = external_api::clean_returnvalue(search_packages::execute_returns(), $res);
+
+        // Check that package order is correct.
+        $actualnamespaces = array_column($res['packages'], 'namespace');
+        $this->assertEquals(array_reverse($namespaces), $actualnamespaces);
+
+        $this->assert_count_and_total($res, $totalpackages, $totalpackages);
+    }
+
+
+    /**
+     * Provides total package count and a limit.
+     *
+     * @return array[]
+     */
+    public static function total_packages_and_limit_provider(): array {
+        return [
+            [1, 2], // Fewer packages than limit.
+            [6, 2], // Only full pages.
+            [7, 3], // Last page has only one item.
+            [8, 3], // Last page is missing one item.
+            [6, 4], // Last page is half as big as limit.
+        ];
+    }
+
+    /**
+     * Tests the date-sorting of the service.
+     *
+     * @param int $limit
+     * @param int $totalpackages
+     * @dataProvider total_packages_and_limit_provider
+     * @covers \qtype_questionpy\external\search_packages::execute
+     * @throws moodle_exception
+     */
+    public function test_limit_and_offset(int $limit, int $totalpackages): void {
+        $this->resetAfterTest();
+
+        for ($i = 0; $i < $totalpackages; $i++) {
+            package_provider(['namespace' => "ns$i"])->store();
+        }
+
+        // Calculate the amount of full pages and the size of the page after the last full page.
+        $fullpages = intdiv($totalpackages, $limit);
+        $lastpagesize = $totalpackages % $limit;
+
+        // Check full pages.
+        for ($page = 0; $page < $fullpages; $page++) {
+            $res = search_packages::execute('', [], 'all', 'alpha', 'asc', $limit, $page);
+            $res = external_api::clean_returnvalue(search_packages::execute_returns(), $res);
+            $this->assert_count_and_total($res, $limit, $totalpackages);
+        }
+
+        // Check first page that is not full.
+        $res = search_packages::execute('', [], 'all', 'alpha', 'asc', $limit, $page);
+        $res = external_api::clean_returnvalue(search_packages::execute_returns(), $res);
+        $this->assert_count_and_total($res, $lastpagesize, $totalpackages);
+
+        // Check that next page is empty.
+        $res = search_packages::execute('', [], 'all', 'alpha', 'asc', $limit, $page + 1);
+        $res = external_api::clean_returnvalue(search_packages::execute_returns(), $res);
+        $this->assert_count_and_total($res, 0, $totalpackages);
+    }
+
+    // TODO: add tests for filtering by tags when localized tags are supported.
+}

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qtype_questionpy';
-$plugin->version = 2022120103;
+$plugin->version = 2022120109;
 $plugin->requires = 2022041901;
 $plugin->maturity = MATURITY_ALPHA;
 $plugin->release = '0.1';


### PR DESCRIPTION
Referenz #68.

Mit diesem PR wird ein neuer Endpunkt zum Suchen von Paketen hinzugefügt.

Dabei wird der Query-Text in einzelne Wörter aufgeteilt, wobei Wörter der Länge eins **nicht** beachtet werden. Alle Wörter müssen im Titel oder (inklusiv) in der Beschreibung der jeweils besten Übersetzung vorhanden sein.

Zum Filtern mit Tags werden die Tag-IDs benötigt.

Aktuell wird nur die `category` `all` unterstützt.

Der Moodle Code Checker gibt fälschlicherweise eine Fehlermeldung aus, dazu existiert schon ein [Issue](https://github.com/moodlehq/moodle-cs/issues/76) und Draft-PR.