### PR TITLE
Feat/search extend arguments with contextid

### DIFF
--- a/classes/external/search_packages.php
+++ b/classes/external/search_packages.php
@@ -40,7 +40,7 @@ use qtype_questionpy\localizer;
 class search_packages extends external_api {
 
     /** @var string[] Valid categories. */
-    const CATEGORIES = ['all', 'lastused', 'favourites', 'mine'];
+    const CATEGORIES = ['all', 'recentlyused', 'favourites', 'mine'];
     /** @var string[] Valid kinds of sorting. */
     const SORT = ['alpha', 'date'];
     /** @var string[] Valid sorting direction. */

--- a/classes/external/search_packages.php
+++ b/classes/external/search_packages.php
@@ -60,6 +60,7 @@ class search_packages extends external_api {
             'order' => new external_value(PARAM_ALPHA),
             'limit' => new external_value(PARAM_INT),
             'page' => new external_value(PARAM_INT),
+            'contextid' => new external_value(PARAM_INT),
         ]);
     }
 
@@ -285,11 +286,12 @@ class search_packages extends external_api {
      * @param string $order
      * @param int $limit
      * @param int $page
+     * @param int $contextid
      * @return array
      * @throws moodle_exception
      */
     public static function execute(string $query, array $tags, string $category, string $sort, string $order,
-                                   int $limit, int $page): array {
+                                   int $limit, int $page, int $contextid): array {
         global $DB;
 
         // Basic parameter validation.
@@ -301,7 +303,12 @@ class search_packages extends external_api {
             'order' => $order,
             'limit' => $limit,
             'page' => $page,
+            'contextid' => $contextid,
         ]);
+
+        // Validate given context id.
+        $context = \context::instance_by_id($contextid, IGNORE_MISSING);
+        self::validate_context($context);
 
         // In addition to the basic parameter validation we also want to validate the values.
         self::validate_parameter_values($params);

--- a/tests/external/search_packages_test.php
+++ b/tests/external/search_packages_test.php
@@ -360,25 +360,19 @@ class search_packages_test extends \externallib_advanced_testcase {
             ['match', 'de', [
                 'ns1' => [['en' => 'en: match'], []],
                 'ns2' => [['en' => 'en: x'], ['en' => 'en: match']],
-                'ns3' => [['en' => 'en: match'], ['en' => 'en: match']]
+                'ns3' => [['en' => 'en: match'], ['en' => 'en: match']],
             ], ['ns1' => ['en', null], 'ns2' => ['en', 'en'], 'ns3' => ['en', 'en']]],
             // Match in fallback language while preferred language does exist but with no match.
             ['match', 'de', [
                 'ns1' => [['en' => 'en: match', 'de' => 'de: x'], []],
                 'ns2' => [['en' => 'en: x'], ['en' => 'en: match', 'de' => 'de: x']],
-                'ns3' => [['en' => 'en: match', 'de' => 'de: x'], ['en' => 'en: match', 'de' => 'de: x']]
+                'ns3' => [['en' => 'en: match', 'de' => 'de: x'], ['en' => 'en: match', 'de' => 'de: x']],
             ], []],
             // Match in fallback language and preferred language.
             ['match', 'de', [
                 'ns1' => [['en' => 'en: match', 'de' => 'de: match'], []],
                 'ns2' => [['en' => 'en: x'], ['en' => 'en: match', 'de' => 'de: match']],
-                'ns3' => [['en' => 'en: match', 'de' => 'de: match'], ['en' => 'en: match', 'de' => 'de: match']]
-            ], ['ns1' => ['de', null], 'ns2' => ['en', 'de'], 'ns3' => ['de', 'de']]],
-            // Match in fallback language and preferred language.
-            ['match', 'de', [
-                'ns1' => [['en' => 'en: match', 'de' => 'de: match'], []],
-                'ns2' => [['en' => 'en: x'], ['en' => 'en: match', 'de' => 'de: match']],
-                'ns3' => [['en' => 'en: match', 'de' => 'de: match'], ['en' => 'en: match', 'de' => 'de: match']]
+                'ns3' => [['en' => 'en: match', 'de' => 'de: match'], ['en' => 'en: match', 'de' => 'de: match']],
             ], ['ns1' => ['de', null], 'ns2' => ['en', 'de'], 'ns3' => ['de', 'de']]],
             // Results must contain every word.
             ['cool match', null, [

--- a/tests/external/search_packages_test.php
+++ b/tests/external/search_packages_test.php
@@ -204,11 +204,11 @@ class search_packages_test extends \externallib_advanced_testcase {
      * @return array
      */
     public static function category_provider(): array {
-        $parameters = [];
-        foreach (['lastused', 'favourites', 'mine'] as $category) {
-            $parameters[] = [$category];
-        }
-        return $parameters;
+        return [
+            ['recentlyused'],
+            ['favourites'],
+            ['mine'],
+        ];
     }
 
     /**
@@ -225,7 +225,7 @@ class search_packages_test extends \externallib_advanced_testcase {
         $this->resetAfterTest();
         $this->setGuestUser();
         $this->expectException(\invalid_parameter_exception::class);
-        search_packages::execute('Test query', [], $category, 'alpha', 'recentlyused', 3, 5, $PAGE->context->id);
+        search_packages::execute('Test query', [], $category, 'alpha', 'up', 3, 5, $PAGE->context->id);
     }
 
     /**


### PR DESCRIPTION
Closes #73.

Zusätzlich wird die Kategorie `lastused` zu `recentlyused` umbenannt.