### PR TITLE
Mehrzeiliges text_area_element und Fallback-Mechanismus für unbekannte Elemente

### DIFF
--- a/classes/array_converter/converter_config.php
+++ b/classes/array_converter/converter_config.php
@@ -36,6 +36,8 @@ class converter_config {
     public ?string $discriminator = null;
     /** @var string[] mapping from discriminator values to concrete classes */
     public array $variants = [];
+    /** @var string|null if an unknown discriminator is given, warn and use this class */
+    public ?string $fallbackvariant;
 
     /** @var string[] mapping from property names to the classes of their array elements */
     public array $elementclasses = [];
@@ -95,9 +97,26 @@ class converter_config {
      * @param string $classname     the concrete class to convert to when the discriminator is encountered
      * @return $this for chaining
      * @see self::discriminate_by()
+     * @see self::fallback_variant()
      */
     public function variant(string $discriminator, string $classname): self {
         $this->variants[$discriminator] = $classname;
+        return $this;
+    }
+
+    /**
+     * Sets the fallback variant for polymorphic deserialization.
+     *
+     * When a discriminator is encountered which isn't {@see variant registered}, the default behaviour is to throw an
+     * exception. Instead, you can register a fallback class to be used. A debugging message will still be emitted.
+     *
+     * @param string $classname the concrete class to convert to when an unknown discriminator is encountered
+     * @return $this for chaining
+     * @see self::discriminate_by()
+     * @see self::variant()
+     */
+    public function fallback_variant(string $classname): self {
+        $this->fallbackvariant = $classname;
         return $this;
     }
 

--- a/classes/form/elements/fallback_element.php
+++ b/classes/form/elements/fallback_element.php
@@ -1,0 +1,52 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\form\elements;
+
+use coding_exception;
+use qtype_questionpy\form\context\render_context;
+
+/**
+ * Fallback element used when the server sends an unsupported element.
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2024 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class fallback_element extends form_element {
+    /** @var string|null */
+    public ?string $name = null;
+
+    /**
+     * Render this item to the given context.
+     *
+     * @param render_context $context target context
+     * @throws coding_exception
+     * @package qtype_questionpy
+     */
+    public function render_to(render_context $context): void {
+        $name = $this->name;
+        if (!$name) {
+            $name = "qpy_fallback_" . $context->next_unique_int();
+        }
+
+        $context->add_element(
+            "warning", $name,
+            null, get_string("form_fallback_element_text", "qtype_questionpy")
+        );
+    }
+}

--- a/classes/form/elements/form_element.php
+++ b/classes/form/elements/form_element.php
@@ -45,5 +45,6 @@ array_converter::configure(form_element::class, function (converter_config $conf
         ->variant("select", select_element::class)
         ->variant("static_text", static_text_element::class)
         ->variant("input", text_input_element::class)
-        ->variant("textarea", text_area_element::class);
+        ->variant("textarea", text_area_element::class)
+        ->fallback_variant(fallback_element::class);
 });

--- a/classes/form/elements/form_element.php
+++ b/classes/form/elements/form_element.php
@@ -44,5 +44,6 @@ array_converter::configure(form_element::class, function (converter_config $conf
         ->variant("repetition", repetition_element::class)
         ->variant("select", select_element::class)
         ->variant("static_text", static_text_element::class)
-        ->variant("input", text_input_element::class);
+        ->variant("input", text_input_element::class)
+        ->variant("textarea", text_area_element::class);
 });

--- a/classes/form/elements/text_area_element.php
+++ b/classes/form/elements/text_area_element.php
@@ -1,0 +1,35 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\form\elements;
+
+use qtype_questionpy\form\context\render_context;
+use qtype_questionpy\form\form_conditions;
+use qtype_questionpy\form\form_help;
+
+/**
+ * Multiline text input element.
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2024 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class text_area_element extends text_input_element {
+
+    /** @var string */
+    protected const MFORM_ELEMENT = "textarea";
+}

--- a/classes/form/elements/text_input_element.php
+++ b/classes/form/elements/text_input_element.php
@@ -25,10 +25,14 @@ use qtype_questionpy\form\form_help;
  *
  * @package    qtype_questionpy
  * @author     Maximilian Haye
- * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @copyright  2024 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class text_input_element extends form_element {
+
+    /** @var string moodle form element name, overridden by {@see text_area_element} */
+    protected const MFORM_ELEMENT = "text";
+
     /** @var string */
     public string $name;
     /** @var string */
@@ -74,7 +78,9 @@ class text_input_element extends form_element {
         $attributes = $this->placeholder ? ["placeholder" => $context->contextualize($this->placeholder)] : [];
 
         $element = $context->add_element(
-            "text", $this->name, $context->contextualize($this->label), $attributes);
+            get_class($this)::MFORM_ELEMENT, $this->name,
+            $context->contextualize($this->label), $attributes
+        );
         $context->set_type($this->name, PARAM_TEXT);
 
         if ($this->default) {

--- a/lang/en/qtype_questionpy.php
+++ b/lang/en/qtype_questionpy.php
@@ -83,6 +83,10 @@ $string['search_sort_label_aria'] = 'Sorting';
 $string['search_sort_alphabetical'] = 'Alphabetical';
 $string['search_sort_creation_date'] = 'Creation Date';
 
+// Package options form.
+$string['form_fallback_element_text'] = "The QuestionPy package is using a form element not supported by the Moodle"
+    . " plugin. Please ensure you are using a compatible package or contact your administrators.";
+
 // Question management.
 $string['package_not_found'] = 'The requested package {$a->packagehash} does not exist.';
 

--- a/tests/data_provider.php
+++ b/tests/data_provider.php
@@ -40,6 +40,7 @@ use qtype_questionpy\form\elements\radio_group_element;
 use qtype_questionpy\form\elements\repetition_element;
 use qtype_questionpy\form\elements\select_element;
 use qtype_questionpy\form\elements\static_text_element;
+use qtype_questionpy\form\elements\text_area_element;
 use qtype_questionpy\form\elements\text_input_element;
 use qtype_questionpy\package\package_raw;
 
@@ -132,5 +133,6 @@ function element_provider(): array {
         ],
         ["static_text", new static_text_element("my_text", "Label", "Lorem ipsum dolor sit amet.")],
         ["input", new text_input_element("my_field", "Label", true, "default", "placeholder")],
+        ["textarea", new text_area_element("my_field", "Label", true, "default", "placeholder")],
     ];
 }

--- a/tests/form/elements/html/textarea.html
+++ b/tests/form/elements/html/textarea.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><body><form id="my_form" autocomplete="off" action="" method="post" accept-charset="utf-8" class="mform">
+	<div style="display: none;"><input name="sesskey" type="hidden" value="sesskey">
+<input name="_qf__qtype_questionpy_form_elements_test_moodleform" type="hidden" value="1">
+</div>
+
+<div id="fitem_id_qpy_form_my_field" class="form-group row  fitem    ">
+    <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
+        
+                <label id="id_qpy_form_my_field_label" class="d-inline word-break " for="id_qpy_form_my_field">
+                    Label
+                </label>
+        
+        <div class="form-label-addon d-flex align-items-center align-self-start">
+                <div class="text-danger" title="Required">
+                <i class="icon fa fa-exclamation-circle text-danger fa-fw " title="Required" role="img" aria-label="Required"></i>
+                </div>
+            
+        </div>
+    </div>
+    <div class="col-md-9 form-inline align-items-start felement" data-fieldtype="textarea">
+        <textarea name="qpy_form[my_field]" id="id_qpy_form_my_field" class="form-control " aria-required="true" placeholder="placeholder">default</textarea>
+        <div class="form-control-feedback invalid-feedback" id="id_error_qpy_form_my_field">
+            
+        </div>
+    </div>
+</div>
+		<div class="fdescription required"><i class="icon fa fa-exclamation-circle text-danger fa-fw " title="Required field" role="img" aria-label="Required field"></i> Required</div>
+</form></body></html>

--- a/tests/form/elements/json/textarea.json
+++ b/tests/form/elements/json/textarea.json
@@ -1,0 +1,11 @@
+{
+  "kind": "textarea",
+  "name": "my_field",
+  "label": "Label",
+  "default": "default",
+  "placeholder": "placeholder",
+  "required": true,
+  "disable_if": [],
+  "hide_if": [],
+  "help": null
+}


### PR DESCRIPTION
Weil der Code für textarea und für text fast gleich ist, ist das text_area_element eine Subklasse von text_input_element geworden.

Damit neue Elemente in Zukunft nicht das ganze Beispielpaket kaputt machen, gibt es jetzt einen Fallback, der folgende Meldung dort anzeigt, wo das unbekannte Element gesessen hätte (und `debugging()` aufruft):
![grafik](https://github.com/questionpy-org/moodle-qtype_questionpy/assets/29020266/96e10f9e-53bf-4149-a90e-9a8fd1a34119)
