### PR TITLE
feat: Recently-Used-Funktionalität

### DIFF
--- a/classes/last_used_service.php
+++ b/classes/last_used_service.php
@@ -1,0 +1,63 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy;
+
+use moodle_exception;
+
+/**
+ * Manages DB entries for recently used QuestionPy packages.
+ *
+ * @package    qtype_questionpy
+ * @copyright  2024 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class last_used_service {
+    /**
+     * Inserts or updates an entry in the database with the current timestamp.
+     *
+     * @param int $contextid
+     * @param int $packageid
+     * @throws moodle_exception
+     */
+    public static function add(int $contextid, int $packageid): void {
+        global $DB;
+
+        $fields = ['contextid' => $contextid, 'packageid' => $packageid];
+        $id = $DB->get_field('qtype_questionpy_lastused', 'id', $fields);
+        $fields['timeused'] = time();
+        if ($id) {
+            // Entry does already exist -> update time.
+            $fields['id'] = $id;
+            $DB->update_record('qtype_questionpy_lastused', $fields);
+        } else {
+            // Create new entry.
+            $DB->insert_record('qtype_questionpy_lastused', $fields);
+        }
+    }
+
+    /**
+     * Removes every entry with the given package id.
+     *
+     * @param int $packageid
+     * @return void
+     * @throws moodle_exception
+     */
+    public static function remove_by_package(int $packageid): void {
+        global $DB;
+        $DB->delete_records('qtype_questionpy_lastused', ['packageid' => $packageid]);
+    }
+}

--- a/classes/package/package.php
+++ b/classes/package/package.php
@@ -20,6 +20,7 @@ use dml_exception;
 use moodle_exception;
 use qtype_questionpy\array_converter\array_converter;
 use qtype_questionpy\array_converter\converter_config;
+use qtype_questionpy\last_used_service;
 
 defined('MOODLE_INTERNAL') || die;
 
@@ -181,7 +182,7 @@ class package extends package_base {
      * Deletes the package and every version from the database.
      *
      * @return void
-     * @throws dml_exception
+     * @throws moodle_exception
      */
     public function delete(): void {
         global $DB;
@@ -190,6 +191,7 @@ class package extends package_base {
         $DB->delete_records('qtype_questionpy_language', ['packageid' => $this->id]);
         $DB->delete_records('qtype_questionpy_tags', ['packageid' => $this->id]);
         $DB->delete_records('qtype_questionpy_package', ['id' => $this->id]);
+        last_used_service::remove_by_package($this->id);
         $transaction->allow_commit();
     }
 

--- a/classes/package/package_version.php
+++ b/classes/package/package_version.php
@@ -18,6 +18,7 @@ namespace qtype_questionpy\package;
 
 use moodle_exception;
 use qtype_questionpy\array_converter\array_converter;
+use qtype_questionpy\last_used_service;
 
 /**
  * Represents a QuestionPy package version stored in the database.
@@ -161,6 +162,9 @@ class package_version {
         $DB->delete_records('qtype_questionpy_language', ['packageid' => $this->packageid]);
         $DB->delete_records('qtype_questionpy_tags', ['packageid' => $this->packageid]);
         $DB->delete_records('qtype_questionpy_package', ['id' => $this->packageid]);
+
+        // Remove the package from the last used table.
+        last_used_service::remove_by_package($this->packageid);
 
         $transaction->allow_commit();
     }

--- a/classes/question_service.php
+++ b/classes/question_service.php
@@ -19,6 +19,7 @@ namespace qtype_questionpy;
 use dml_exception;
 use moodle_exception;
 use qtype_questionpy\api\api;
+use qtype_questionpy\package\package;
 use qtype_questionpy\package\package_version;
 use stdClass;
 
@@ -139,6 +140,8 @@ class question_service {
                     (object)['packagehash' => $question->qpy_package_hash]
                 );
             }
+            $packageid = package::get_by_version($pkgversionid)->id;
+            last_used_service::add($question->context->id, $packageid);
         }
 
         $existingrecord = $DB->get_record(self::QUESTION_TABLE, [

--- a/db/install.xml
+++ b/db/install.xml
@@ -108,6 +108,9 @@
         <KEY NAME="contextid" TYPE="foreign" FIELDS="contextid" REFTABLE="context" REFFIELDS="id"/>
         <KEY NAME="packageid" TYPE="foreign" FIELDS="packageid" REFTABLE="qtype_questionpy_package" REFFIELDS="id"/>
       </KEYS>
+      <INDEXES>
+        <INDEX NAME="contextid-packageid" UNIQUE="true" FIELDS="contextid, packageid"/>
+      </INDEXES>
     </TABLE>
 
   </TABLES>

--- a/tests/last_used_service_test.php
+++ b/tests/last_used_service_test.php
@@ -1,0 +1,219 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy;
+
+use moodle_exception;
+
+/**
+ * Unit tests for {@see last_used_service}.
+ *
+ * @package    qtype_questionpy
+ * @copyright  2024 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class last_used_service_test extends \advanced_testcase {
+    /**
+     * Tests {@see last_used_service::add()} create correct timestamp.
+     *
+     * @throws moodle_exception
+     * @covers \qtype_questionpy\last_used_service::add
+     */
+    public function test_add_creates_entry() {
+        global $DB;
+        $this->resetAfterTest();
+
+        $contextid = 0;
+        $packageid = 0;
+
+        last_used_service::add($contextid, $packageid);
+
+        $record = $DB->get_record('qtype_questionpy_lastused', ['contextid' => $contextid, 'packageid' => $packageid]);
+        $this->assertNotFalse($record);
+        $this->assertTimeCurrent($record->timeused);
+    }
+
+    /**
+     * Tests {@see last_used_service::add()} only updates the timestamp if the context-package-combination is already in
+     * the table.
+     *
+     * @throws moodle_exception
+     * @covers \qtype_questionpy\last_used_service::add
+     */
+    public function test_add_updates_timestamp_if_package_was_already_used() {
+        global $DB;
+        $this->resetAfterTest();
+
+        $contextid = 0;
+        $packageid = 0;
+
+        last_used_service::add($contextid, $packageid);
+        $oldrecord = $DB->get_record('qtype_questionpy_lastused', ['contextid' => $contextid, 'packageid' => $packageid]);
+
+        $this->waitForSecond();
+
+        last_used_service::add($contextid, $packageid);
+        $newrecord = $DB->get_record('qtype_questionpy_lastused', ['contextid' => $contextid, 'packageid' => $packageid]);
+
+        $this->assertTimeCurrent($newrecord->timeused);
+        $this->assertGreaterThan($oldrecord->timeused, $newrecord->timeused);
+
+        $count = $DB->count_records('qtype_questionpy_lastused');
+        $this->assertEquals(1, $count);
+    }
+
+    /**
+     * Tests {@see last_used_service::add()} inserts multiple entries when the packages differ.
+     *
+     * @throws moodle_exception
+     * @covers \qtype_questionpy\last_used_service::add
+     */
+    public function test_add_inserts_entries_if_packages_differ() {
+        global $DB;
+        $this->resetAfterTest();
+
+        $contextid = 0;
+        $package1id = 0;
+        $package2id = 1;
+
+        last_used_service::add($contextid, $package1id);
+        last_used_service::add($contextid, $package2id);
+
+        $entry1 = $DB->record_exists('qtype_questionpy_lastused', ['contextid' => $contextid, 'packageid' => $package1id]);
+        $this->assertTrue($entry1);
+        $entry2 = $DB->record_exists('qtype_questionpy_lastused', ['contextid' => $contextid, 'packageid' => $package2id]);
+        $this->assertTrue($entry2);
+
+        $count = $DB->count_records('qtype_questionpy_lastused');
+        $this->assertEquals(2, $count);
+    }
+
+    /**
+     * Tests {@see last_used_service::add()} inserts multiple entries when the contexts differ.
+     *
+     * @throws moodle_exception
+     * @covers \qtype_questionpy\last_used_service::add
+     */
+    public function test_add_inserts_entries_if_contexts_differ() {
+        global $DB;
+        $this->resetAfterTest();
+
+        $context1id = 0;
+        $context2id = 1;
+        $packageid = 0;
+
+        last_used_service::add($context1id, $packageid);
+        last_used_service::add($context2id, $packageid);
+
+        $entry1 = $DB->record_exists('qtype_questionpy_lastused', ['contextid' => $context1id, 'packageid' => $packageid]);
+        $this->assertTrue($entry1);
+        $entry2 = $DB->record_exists('qtype_questionpy_lastused', ['contextid' => $context2id, 'packageid' => $packageid]);
+        $this->assertTrue($entry2);
+
+        $count = $DB->count_records('qtype_questionpy_lastused');
+        $this->assertEquals(2, $count);
+    }
+
+    /**
+     * Tests {@see last_used_service::add()} inserts multiple entries when the packages and contexts differ.
+     *
+     * @throws moodle_exception
+     * @covers \qtype_questionpy\last_used_service::add
+     */
+    public function test_add_inserts_entries_if_packages_and_contexts_differ() {
+        global $DB;
+        $this->resetAfterTest();
+
+        $context1id = 0;
+        $context2id = 1;
+        $package1id = 0;
+        $package2id = 1;
+
+        last_used_service::add($context1id, $package1id);
+        last_used_service::add($context2id, $package2id);
+
+        $entry1 = $DB->record_exists('qtype_questionpy_lastused', ['contextid' => $context1id, 'packageid' => $package1id]);
+        $this->assertTrue($entry1);
+        $entry2 = $DB->record_exists('qtype_questionpy_lastused', ['contextid' => $context2id, 'packageid' => $package2id]);
+        $this->assertTrue($entry2);
+
+        $count = $DB->count_records('qtype_questionpy_lastused');
+        $this->assertEquals(2, $count);
+    }
+
+    /**
+     * Provides context counts.
+     *
+     * @return array[]
+     */
+    public static function context_count_provider(): array {
+        return [
+            [0],
+            [1],
+            [5],
+        ];
+    }
+
+    /**
+     * Tests {@see last_used_service::remove_by_package()} removes every entry with the given package.
+     *
+     * @param int $contexts
+     * @throws moodle_exception
+     * @dataProvider context_count_provider
+     * @covers \qtype_questionpy\last_used_service::remove_by_package
+     */
+    public function test_remove_by_package_removes_the_entries(int $contexts) {
+        global $DB;
+        $this->resetAfterTest();
+
+        $packageid = 0;
+
+        for ($contextid = 0; $contextid < $contexts; $contextid++) {
+            last_used_service::add($contextid, $packageid);
+        }
+
+        last_used_service::remove_by_package($packageid);
+
+        $count = $DB->count_records('qtype_questionpy_lastused');
+        $this->assertEquals(0, $count);
+    }
+
+    /**
+     * Tests {@see last_used_service::remove_by_package()} only removes the given package.
+     *
+     * @throws moodle_exception
+     * @covers \qtype_questionpy\last_used_service::remove_by_package
+     */
+    public function test_remove_by_package_only_removes_the_given_package() {
+        global $DB;
+        $this->resetAfterTest();
+
+        $contextid = 0;
+        $package1id = 0;
+        $package2id = 1;
+
+        last_used_service::add($contextid, $package1id);
+        last_used_service::add($contextid, $package2id);
+
+        last_used_service::remove_by_package($package1id);
+
+        $count = $DB->count_records('qtype_questionpy_lastused');
+        $this->assertEquals(1, $count);
+
+        $entry = $DB->record_exists('qtype_questionpy_lastused', ['contextid' => $contextid, 'packageid' => $package2id]);
+        $this->assertTrue($entry);
+    }
+}


### PR DESCRIPTION
Nach dem Speichern einer Frage wird ein Eintrag in die `qtype_questionpy_lastused`-Tabelle mit der aktuellen Zeit gemacht. Sollte in diesem Kontext bereits genau das Paket (die Version ist egal) ausgewählt worden sein, so wird nur der Zeitstempel aktualisiert.