### PR TITLE
Verwendung des `moodle-extra`-Coding-Standards

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Moodle Code Checker
         if: ${{ !cancelled() }}
-        run: moodle-plugin-ci phpcs --max-warnings 0
+        run: moodle-plugin-ci phpcs --standard moodle-extra --exclude moodle.Commenting.TodoComment,Squiz.Functions.MultiLineFunctionDeclaration --max-warnings 0
 
       - name: Moodle PHPDoc Checker
         if: ${{ !cancelled() }}

--- a/backup/moodle2/backup_qtype_questionpy_plugin.class.php
+++ b/backup/moodle2/backup_qtype_questionpy_plugin.class.php
@@ -29,7 +29,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class backup_qtype_questionpy_plugin extends backup_qtype_plugin {
-
     /**
      * Returns the qtype information to attach to question element
      */

--- a/backup/moodle2/restore_qtype_questionpy_plugin.class.php
+++ b/backup/moodle2/restore_qtype_questionpy_plugin.class.php
@@ -29,7 +29,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class restore_qtype_questionpy_plugin extends restore_qtype_plugin {
-
     /**
      * Returns the paths to be handled by the plugin at question level
      *

--- a/classes/api/api.php
+++ b/classes/api/api.php
@@ -30,7 +30,6 @@ use TypeError;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class api {
-
     /**
      * Retrieves QuestionPy packages from the application server.
      *

--- a/classes/api/attempt.php
+++ b/classes/api/attempt.php
@@ -25,7 +25,6 @@ namespace qtype_questionpy\api;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class attempt {
-
     /** @var int */
     public int $variant;
 

--- a/classes/api/attempt_scored.php
+++ b/classes/api/attempt_scored.php
@@ -30,7 +30,6 @@ defined('MOODLE_INTERNAL') || die;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class attempt_scored extends attempt {
-
     /** @var string */
     public string $scoringstate;
 

--- a/classes/api/attempt_started.php
+++ b/classes/api/attempt_started.php
@@ -30,7 +30,6 @@ defined('MOODLE_INTERNAL') || die;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class attempt_started extends attempt {
-
     /** @var string */
     public string $attemptstate;
 

--- a/classes/api/attempt_ui.php
+++ b/classes/api/attempt_ui.php
@@ -30,7 +30,6 @@ defined('MOODLE_INTERNAL') || die;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class attempt_ui {
-
     /** @var string */
     public string $content;
 

--- a/classes/api/classified_response.php
+++ b/classes/api/classified_response.php
@@ -30,7 +30,6 @@ defined('MOODLE_INTERNAL') || die;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class classified_response {
-
     /** @var string */
     public string $subquestionid;
 

--- a/classes/api/connector.php
+++ b/classes/api/connector.php
@@ -26,7 +26,6 @@ use moodle_exception;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class connector {
-
     /**
      * @var string server url
      */
@@ -60,8 +59,11 @@ class connector {
 
         if (!$this->curlhandle) {
             throw new moodle_exception(
-                'curl_init_error', 'qtype_questionpy', '',
-                curl_errno($this->curlhandle), curl_error($this->curlhandle)
+                'curl_init_error',
+                'qtype_questionpy',
+                '',
+                curl_errno($this->curlhandle),
+                curl_error($this->curlhandle)
             );
         }
 
@@ -105,8 +107,11 @@ class connector {
 
         if (!$success) {
             throw new moodle_exception(
-                'curl_set_opt_error', 'qtype_questionpy', '',
-                curl_errno($this->curlhandle), curl_error($this->curlhandle)
+                'curl_set_opt_error',
+                'qtype_questionpy',
+                '',
+                curl_errno($this->curlhandle),
+                curl_error($this->curlhandle)
             );
         }
     }
@@ -122,8 +127,11 @@ class connector {
 
         if (!$success) {
             throw new moodle_exception(
-                'curl_set_opt_error', 'qtype_questionpy', '',
-                curl_errno($this->curlhandle), curl_error($this->curlhandle)
+                'curl_set_opt_error',
+                'qtype_questionpy',
+                '',
+                curl_errno($this->curlhandle),
+                curl_error($this->curlhandle)
             );
         }
     }
@@ -151,8 +159,11 @@ class connector {
         // Check for cURL failure.
         if ($data === false) {
             throw new moodle_exception(
-                'curl_exec_error', 'qtype_questionpy', '',
-                curl_errno($this->curlhandle), curl_error($this->curlhandle)
+                'curl_exec_error',
+                'qtype_questionpy',
+                '',
+                curl_errno($this->curlhandle),
+                curl_error($this->curlhandle)
             );
         }
 
@@ -208,5 +219,4 @@ class connector {
         // Execute POST request.
         return $this->exec();
     }
-
 }

--- a/classes/api/package_api.php
+++ b/classes/api/package_api.php
@@ -31,7 +31,6 @@ use stored_file;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class package_api {
-
     /** @var string */
     private string $hash;
 

--- a/classes/api/question_edit_form_response.php
+++ b/classes/api/question_edit_form_response.php
@@ -53,5 +53,3 @@ array_converter::configure(question_edit_form_response::class, function (convert
     $config
         ->rename("formdata", "form_data");
 });
-
-

--- a/classes/api/question_response.php
+++ b/classes/api/question_response.php
@@ -76,5 +76,3 @@ array_converter::configure(question_response::class, function (converter_config 
         ->rename("rendereveryview", "render_every_view")
         ->rename("generalfeedback", "general_feedback");
 });
-
-

--- a/classes/api/status.php
+++ b/classes/api/status.php
@@ -30,7 +30,6 @@ defined('MOODLE_INTERNAL') || die;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class status {
-
     /** @var string */
     public string $name;
 

--- a/classes/api/usage.php
+++ b/classes/api/usage.php
@@ -31,7 +31,6 @@ defined('MOODLE_INTERNAL') || die;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class usage {
-
     /** @var int */
     public int $requestsinprocess;
 

--- a/classes/array_converter/array_converter.php
+++ b/classes/array_converter/array_converter.php
@@ -31,7 +31,6 @@ use ReflectionNamedType;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class array_converter {
-
     /** @var callable[] associative array of class names to configuration hook functions for those classes */
     private static array $hooks = [];
 
@@ -75,7 +74,10 @@ class array_converter {
                 if ($discriminator !== null && $discriminator !== $expected) {
                     // If the wrong discriminator is given, it is an error.
                     throw new moodle_exception(
-                        "cannotgetdata", "error", "", null,
+                        "cannotgetdata",
+                        "error",
+                        "",
+                        null,
                         "Expected '$config->discriminator' value '$expected', but got '$discriminator'"
                     );
                 }
@@ -188,7 +190,10 @@ class array_converter {
                     $args[] = $parameter->getDefaultValue();
                 } else if (!$parameter->isVariadic()) {
                     throw new moodle_exception(
-                        "cannotgetdata", "error", "", null,
+                        "cannotgetdata",
+                        "error",
+                        "",
+                        null,
                         "No value provided for required field '$parameter->name' of '{$reflect->getName()}'"
                     );
                 }
@@ -212,7 +217,7 @@ class array_converter {
      * @throws moodle_exception if a value in the raw array cannot be converted to the type of the matching property
      */
     private static function set_properties(ReflectionClass $reflect, converter_config $config,
-                                           object          $instance, array &$raw): void {
+                                           object $instance, array &$raw): void {
         $properties = $reflect->getProperties();
         foreach ($properties as $property) {
             if ($property->isStatic()) {
@@ -232,7 +237,8 @@ class array_converter {
 
             $property->setAccessible(true);
             $property->setValue(
-                $instance, self::convert_to_required_type($property->getType(), $config, $property->name, $value)
+                $instance,
+                self::convert_to_required_type($property->getType(), $config, $property->name, $value)
             );
             unset($raw[$key]);
         }
@@ -274,7 +280,7 @@ class array_converter {
      * @throws moodle_exception if the value cannot be converted to the given type
      */
     private static function convert_to_required_type(?ReflectionNamedType $type, converter_config $config,
-                                                     string               $propname, $value) {
+                                                     string $propname, $value) {
         if (!is_array($value) || !$type) {
             // For scalars and untyped properties / parameters, no conversion is done.
             return $value;
@@ -299,7 +305,10 @@ class array_converter {
 
         $actualtype = gettype($value);
         throw new moodle_exception(
-            "cannotgetdata", "error", "", null,
+            "cannotgetdata",
+            "error",
+            "",
+            null,
             "Cannot convert value of type '$actualtype' to type '{$type->getName()}'"
         );
     }

--- a/classes/external/favourite_package.php
+++ b/classes/external/favourite_package.php
@@ -38,7 +38,6 @@ use qtype_questionpy\utils;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class favourite_package extends external_api {
-
     /**
      * Used to verify the parameters passed to the service.
      *

--- a/classes/external/load_packages.php
+++ b/classes/external/load_packages.php
@@ -39,7 +39,6 @@ use qtype_questionpy\package\package_version;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class load_packages extends external_api {
-
     /**
      * Used to verify the parameters passed to the service - this services does not allow any parameters.
      *

--- a/classes/external/remove_packages.php
+++ b/classes/external/remove_packages.php
@@ -36,7 +36,6 @@ use qtype_questionpy\package\package_version;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class remove_packages extends external_api {
-
     /**
      * Used to verify the parameters passed to the service - this services does not allow any parameters.
      *

--- a/classes/external/search_packages.php
+++ b/classes/external/search_packages.php
@@ -42,7 +42,6 @@ use qtype_questionpy\package\package_version;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class search_packages extends external_api {
-
     /** @var string[] Valid categories. */
     const CATEGORIES = ['all', 'recentlyused', 'favourites'];
     /** @var string[] Valid kinds of sorting. */

--- a/classes/form/conditions/condition.php
+++ b/classes/form/conditions/condition.php
@@ -30,7 +30,6 @@ defined('MOODLE_INTERNAL') || die;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 abstract class condition {
-
     /** @var string $name name of the target element */
     public string $name;
 

--- a/classes/form/conditions/condition_with_value.php
+++ b/classes/form/conditions/condition_with_value.php
@@ -25,7 +25,6 @@ namespace qtype_questionpy\form\conditions;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 abstract class condition_with_value extends condition {
-
     /** @var mixed value which the target element value will be compared with */
     public $value;
 

--- a/classes/form/conditions/does_not_equal.php
+++ b/classes/form/conditions/does_not_equal.php
@@ -25,7 +25,6 @@ namespace qtype_questionpy\form\conditions;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class does_not_equal extends condition_with_value {
-
     /**
      * Return the condition string to pass to {@see \MoodleQuickForm::disabledIf()} or {@see \MoodleQuickForm::hideIf()}
      * after the depended on element's name.

--- a/classes/form/conditions/equals.php
+++ b/classes/form/conditions/equals.php
@@ -25,7 +25,6 @@ namespace qtype_questionpy\form\conditions;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class equals extends condition_with_value {
-
     /**
      * Return the condition string to pass to {@see \MoodleQuickForm::disabledIf()} or {@see \MoodleQuickForm::hideIf()}
      * after the depended on element's name.

--- a/classes/form/conditions/in.php
+++ b/classes/form/conditions/in.php
@@ -25,7 +25,6 @@ namespace qtype_questionpy\form\conditions;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class in extends condition_with_value {
-
     /**
      * Return the condition string to pass to {@see \MoodleQuickForm::disabledIf()} or {@see \MoodleQuickForm::hideIf()}
      * after the depended on element's name.

--- a/classes/form/conditions/is_checked.php
+++ b/classes/form/conditions/is_checked.php
@@ -25,7 +25,6 @@ namespace qtype_questionpy\form\conditions;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class is_checked extends condition {
-
     /**
      * Return the condition string to pass to {@see \MoodleQuickForm::disabledIf()} or {@see \MoodleQuickForm::hideIf()}
      * after the depended on element's name.

--- a/classes/form/conditions/is_not_checked.php
+++ b/classes/form/conditions/is_not_checked.php
@@ -25,7 +25,6 @@ namespace qtype_questionpy\form\conditions;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class is_not_checked extends condition {
-
     /**
      * Return the condition string to pass to {@see \MoodleQuickForm::disabledIf()} or {@see \MoodleQuickForm::hideIf()}
      * after the depended on element's name.

--- a/classes/form/context/array_render_context.php
+++ b/classes/form/context/array_render_context.php
@@ -72,7 +72,9 @@ class array_render_context extends render_context {
     public function __construct(render_context $parent, string $prefix) {
         $this->parent = $parent;
         parent::__construct(
-            $parent->moodleform, $parent->mform, $prefix,
+            $parent->moodleform,
+            $parent->mform,
+            $prefix,
             utils::array_get_nested($parent->data, $prefix) ?? []
         );
     }
@@ -130,10 +132,11 @@ class array_render_context extends render_context {
      * @param bool $force             force the rule to be applied, even if the target form element does not exist.
      * @see \MoodleQuickForm::addRule()
      */
-    public function add_rule(string  $name, ?string $message, string $type, ?string $format = null,
+    public function add_rule(string $name, ?string $message, string $type, ?string $format = null,
                              ?string $validation = "server", bool $reset = false, bool $force = false): void {
         utils::ensure_exists(
-            $this->rules, $this->mangle_name($name)
+            $this->rules,
+            $this->mangle_name($name)
         )[] = [$message, $type, $format, $validation, $reset, $force];
     }
 

--- a/classes/form/context/mform_render_context.php
+++ b/classes/form/context/mform_render_context.php
@@ -29,7 +29,6 @@ use qtype_questionpy\utils;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 abstract class mform_render_context extends render_context {
-
     /**
      * Create, add and return an element.
      *
@@ -83,7 +82,7 @@ abstract class mform_render_context extends render_context {
      * @param bool $force             force the rule to be applied, even if the target form element does not exist.
      * @see \MoodleQuickForm::addRule()
      */
-    public function add_rule(string  $name, ?string $message, string $type, ?string $format = null,
+    public function add_rule(string $name, ?string $message, string $type, ?string $format = null,
                              ?string $validation = "server", bool $reset = false, bool $force = false): void {
         $this->mform->addRule($this->mangle_name($name), $message, $type, $format, $validation, $reset, $force);
     }

--- a/classes/form/context/render_context.php
+++ b/classes/form/context/render_context.php
@@ -114,7 +114,7 @@ abstract class render_context {
      * @param bool $force             force the rule to be applied, even if the target form element does not exist.
      * @see MoodleQuickForm::addRule
      */
-    abstract public function add_rule(string  $name, ?string $message, string $type, ?string $format = null,
+    abstract public function add_rule(string $name, ?string $message, string $type, ?string $format = null,
                                       ?string $validation = "server", bool $reset = false, bool $force = false): void;
 
     /**

--- a/classes/form/context/repetition_render_context.php
+++ b/classes/form/context/repetition_render_context.php
@@ -30,7 +30,6 @@ use qtype_questionpy\form\elements\repetition_element;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class repetition_render_context extends section_render_context {
-
     /** @var int running number of this repetition iteration, starting at 1 and not counting removed reps */
     private int $humanrepno;
 

--- a/classes/form/context/root_render_context.php
+++ b/classes/form/context/root_render_context.php
@@ -25,7 +25,6 @@ namespace qtype_questionpy\form\context;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class root_render_context extends mform_render_context {
-
     /** @var int the next int which will be returned by {@see next_unique_int} */
     private int $nextuniqueint = 1;
 

--- a/classes/form/context/section_render_context.php
+++ b/classes/form/context/section_render_context.php
@@ -41,7 +41,8 @@ class section_render_context extends mform_render_context {
     public function __construct(render_context $parent, string $name) {
         $this->parent = $parent;
         parent::__construct(
-            $parent->moodleform, $parent->mform,
+            $parent->moodleform,
+            $parent->mform,
             $parent->mangle_name($name),
             utils::array_get_nested($parent->data, $name) ?? []
         );

--- a/classes/form/dynamic_help_icon.php
+++ b/classes/form/dynamic_help_icon.php
@@ -36,8 +36,7 @@ use stdClass;
  * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class dynamic_help_icon implements renderable, named_templatable {
-
+class dynamic_help_icon implements named_templatable, renderable {
     /** @var string|null */
     private ?string $title;
     /** @var string */

--- a/classes/form/elements/checkbox_element.php
+++ b/classes/form/elements/checkbox_element.php
@@ -34,6 +34,9 @@ defined('MOODLE_INTERNAL') || die;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class checkbox_element extends form_element {
+    use form_conditions;
+    use form_help;
+
     /** @var string */
     public string $name;
     /** @var string|null */
@@ -45,8 +48,6 @@ class checkbox_element extends form_element {
     /** @var bool */
     public bool $selected = false;
 
-    use form_conditions, form_help;
-
     /**
      * Initializes the element.
      *
@@ -57,7 +58,7 @@ class checkbox_element extends form_element {
      * @param bool $selected
      */
     public function __construct(string $name, ?string $leftlabel = null, ?string $rightlabel = null,
-                                bool   $required = false, bool $selected = false) {
+                                bool $required = false, bool $selected = false) {
         $this->name = $name;
         $this->leftlabel = $leftlabel;
         $this->rightlabel = $rightlabel;
@@ -75,7 +76,8 @@ class checkbox_element extends form_element {
      */
     public function render_to(render_context $context, ?int $group = null): void {
         $element = $context->add_element(
-            "advcheckbox", $this->name,
+            "advcheckbox",
+            $this->name,
             $context->contextualize($this->leftlabel),
             $context->contextualize($this->rightlabel),
             $group ? ["group" => $group] : null

--- a/classes/form/elements/checkbox_group_element.php
+++ b/classes/form/elements/checkbox_group_element.php
@@ -40,7 +40,7 @@ class checkbox_group_element extends form_element {
      *
      * @param checkbox_element ...$checkboxes
      */
-    public function __construct(checkbox_element...$checkboxes) {
+    public function __construct(checkbox_element ...$checkboxes) {
         $this->checkboxes = $checkboxes;
     }
 

--- a/classes/form/elements/fallback_element.php
+++ b/classes/form/elements/fallback_element.php
@@ -45,8 +45,10 @@ class fallback_element extends form_element {
         }
 
         $context->add_element(
-            "warning", $name,
-            null, get_string("form_fallback_element_text", "qtype_questionpy")
+            "warning",
+            $name,
+            null,
+            get_string("form_fallback_element_text", "qtype_questionpy")
         );
     }
 }

--- a/classes/form/elements/group_element.php
+++ b/classes/form/elements/group_element.php
@@ -35,14 +35,15 @@ defined('MOODLE_INTERNAL') || die;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class group_element extends form_element {
+    use form_conditions;
+    use form_help;
+
     /** @var string */
     public string $name;
     /** @var string */
     public string $label;
     /** @var form_element[] */
     public array $elements;
-
-    use form_conditions, form_help;
 
     /**
      * Initializes the element.
@@ -72,9 +73,12 @@ class group_element extends form_element {
         }
 
         $element = $context->add_element(
-            "group", $groupname,
+            "group",
+            $groupname,
             $context->contextualize($this->label),
-            $innercontext->elements, null, false
+            $innercontext->elements,
+            null,
+            false
         );
 
         foreach ($innercontext->types as $name => $type) {

--- a/classes/form/elements/hidden_element.php
+++ b/classes/form/elements/hidden_element.php
@@ -28,12 +28,12 @@ use qtype_questionpy\form\form_conditions;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class hidden_element extends form_element {
+    use form_conditions;
+
     /** @var string */
     public string $name;
     /** @var string */
     public string $value;
-
-    use form_conditions;
 
     /**
      * Initializes the element.

--- a/classes/form/elements/option.php
+++ b/classes/form/elements/option.php
@@ -42,7 +42,7 @@ class option {
     public function __construct(
         string $label,
         string $value,
-        bool   $selected = false
+        bool $selected = false
     ) {
         $this->label = $label;
         $this->value = $value;

--- a/classes/form/elements/radio_group_element.php
+++ b/classes/form/elements/radio_group_element.php
@@ -33,6 +33,9 @@ defined('MOODLE_INTERNAL') || die;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class radio_group_element extends form_element {
+    use form_conditions;
+    use form_help;
+
     /** @var string */
     public string $name;
     /** @var string */
@@ -41,8 +44,6 @@ class radio_group_element extends form_element {
     public array $options;
     /** @var bool */
     public bool $required = false;
-
-    use form_conditions, form_help;
 
     /**
      * Initializes the element.
@@ -74,14 +75,21 @@ class radio_group_element extends form_element {
             }
 
             $radioarray[] = $context->mform->createElement(
-                "radio", $mangledname, null,
-                $context->contextualize($option->label), $option->value
+                "radio",
+                $mangledname,
+                null,
+                $context->contextualize($option->label),
+                $option->value
             );
         }
 
         $group = $context->add_element(
-            "group", "radio_group_" . $this->name, $context->contextualize($this->label),
-            $radioarray, null, false
+            "group",
+            "radio_group_" . $this->name,
+            $context->contextualize($this->label),
+            $radioarray,
+            null,
+            false
         );
 
         if ($default) {

--- a/classes/form/elements/repetition_element.php
+++ b/classes/form/elements/repetition_element.php
@@ -58,7 +58,7 @@ class repetition_element extends form_element {
      * @param form_element[] $elements
      */
     public function __construct(string $name, int $initialrepetitions, int $increment, ?string $buttonlabel,
-                                array  $elements) {
+                                array $elements) {
         $this->name = $name;
         $this->initialrepetitions = $initialrepetitions;
         $this->increment = $increment;

--- a/classes/form/elements/select_element.php
+++ b/classes/form/elements/select_element.php
@@ -34,6 +34,9 @@ defined('MOODLE_INTERNAL') || die;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class select_element extends form_element {
+    use form_conditions;
+    use form_help;
+
     /** @var string */
     public string $name;
     /** @var string */
@@ -45,8 +48,6 @@ class select_element extends form_element {
     /** @var bool */
     public bool $required = false;
 
-    use form_conditions, form_help;
-
     /**
      * Initializes the element.
      *
@@ -57,7 +58,7 @@ class select_element extends form_element {
      * @param bool $required
      */
     public function __construct(string $name, string $label, array $options, bool $multiple = false,
-                                bool   $required = false) {
+                                bool $required = false) {
         $this->name = $name;
         $this->label = $label;
         $this->options = $options;
@@ -83,8 +84,11 @@ class select_element extends form_element {
         // phpcs:disable moodle.Commenting.InlineComment.DocBlock
         /** @var $element HTML_QuickForm_select */
         $element = $context->add_element(
-            "select", $this->name,
-            $context->contextualize($this->label), $optionsassociative);
+            "select",
+            $this->name,
+            $context->contextualize($this->label),
+            $optionsassociative
+        );
 
         $element->setMultiple($this->multiple);
         if ($selected) {

--- a/classes/form/elements/static_text_element.php
+++ b/classes/form/elements/static_text_element.php
@@ -29,14 +29,15 @@ use qtype_questionpy\form\form_help;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class static_text_element extends form_element {
+    use form_conditions;
+    use form_help;
+
     /** @var string */
     public string $name;
     /** @var string */
     public string $label;
     /** @var string */
     public string $text;
-
-    use form_conditions, form_help;
 
     /**
      * Initializes the element.
@@ -58,8 +59,10 @@ class static_text_element extends form_element {
      */
     public function render_to(render_context $context): void {
         $element = $context->add_element(
-            "static", $this->name,
-            $context->contextualize($this->label), $context->contextualize($this->text)
+            "static",
+            $this->name,
+            $context->contextualize($this->label),
+            $context->contextualize($this->text)
         );
 
         $this->render_conditions($context, $this->name);

--- a/classes/form/elements/text_area_element.php
+++ b/classes/form/elements/text_area_element.php
@@ -29,7 +29,6 @@ use qtype_questionpy\form\form_help;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class text_area_element extends text_input_element {
-
     /** @var string */
     protected const MFORM_ELEMENT = "textarea";
 }

--- a/classes/form/elements/text_input_element.php
+++ b/classes/form/elements/text_input_element.php
@@ -29,6 +29,8 @@ use qtype_questionpy\form\form_help;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class text_input_element extends form_element {
+    use form_conditions;
+    use form_help;
 
     /** @var string moodle form element name, overridden by {@see text_area_element} */
     protected const MFORM_ELEMENT = "text";
@@ -44,8 +46,6 @@ class text_input_element extends form_element {
     /** @var string|null */
     public ?string $placeholder = null;
 
-    use form_conditions, form_help;
-
     /**
      * Initializes the element.
      *
@@ -56,9 +56,9 @@ class text_input_element extends form_element {
      * @param string|null $placeholder
      */
     public function __construct(
-        string  $name,
-        string  $label,
-        bool    $required = false,
+        string $name,
+        string $label,
+        bool $required = false,
         ?string $default = null,
         ?string $placeholder = null
     ) {
@@ -78,8 +78,10 @@ class text_input_element extends form_element {
         $attributes = $this->placeholder ? ["placeholder" => $context->contextualize($this->placeholder)] : [];
 
         $element = $context->add_element(
-            get_class($this)::MFORM_ELEMENT, $this->name,
-            $context->contextualize($this->label), $attributes
+            get_class($this)::MFORM_ELEMENT,
+            $this->name,
+            $context->contextualize($this->label),
+            $attributes
         );
         $context->set_type($this->name, PARAM_TEXT);
 

--- a/classes/form/form_help.php
+++ b/classes/form/form_help.php
@@ -27,7 +27,6 @@ use HTML_QuickForm_element;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 trait form_help {
-
     /** @var string|null */
     public ?string $help = null;
 

--- a/classes/form/form_section.php
+++ b/classes/form/form_section.php
@@ -33,7 +33,6 @@ defined('MOODLE_INTERNAL') || die;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class form_section implements qpy_renderable {
-
     /** @var string */
     public string $name;
 

--- a/classes/localizer.php
+++ b/classes/localizer.php
@@ -24,7 +24,6 @@ namespace qtype_questionpy;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class localizer {
-
     /**
      * Generates sorted list with languages from most to least preferred.
      *

--- a/classes/package/package.php
+++ b/classes/package/package.php
@@ -33,7 +33,6 @@ defined('MOODLE_INTERNAL') || die;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class package extends package_base {
-
     /**
      * @var int package id
      */
@@ -61,7 +60,17 @@ class package extends package_base {
                                 ?array $tags = null) {
         $this->id = $id;
         parent::__construct(
-            $shortname, $namespace, $name, $type, $author, $url, $languages, $description, $icon, $license, $tags
+            $shortname,
+            $namespace,
+            $name,
+            $type,
+            $author,
+            $url,
+            $languages,
+            $description,
+            $icon,
+            $license,
+            $tags
         );
     }
 

--- a/classes/package/package_base.php
+++ b/classes/package/package_base.php
@@ -27,7 +27,6 @@ use qtype_questionpy\array_converter\array_converter;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class package_base {
-
     /**
      * @var string package shortname
      */
@@ -100,8 +99,8 @@ class package_base {
      */
     public function __construct(string $shortname, string $namespace, array $name, string $type,
                                 ?string $author = null, ?string $url = null, ?array $languages = null,
-                                ?array  $description = null, ?string $icon = null, ?string $license = null,
-                                ?array  $tags = null) {
+                                ?array $description = null, ?string $icon = null, ?string $license = null,
+                                ?array $tags = null) {
         $this->shortname = $shortname;
         $this->namespace = $namespace;
         $this->name = $name;

--- a/classes/package/package_raw.php
+++ b/classes/package/package_raw.php
@@ -33,7 +33,6 @@ defined('MOODLE_INTERNAL') || die;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class package_raw extends package_base {
-
     /**
      * @var string package hash
      */
@@ -68,7 +67,17 @@ class package_raw extends package_base {
         $this->hash = $hash;
         $this->version = $version;
         parent::__construct(
-            $shortname, $namespace, $name, $type, $author, $url, $languages, $description, $icon, $license, $tags
+            $shortname,
+            $namespace,
+            $name,
+            $type,
+            $author,
+            $url,
+            $languages,
+            $description,
+            $icon,
+            $license,
+            $tags
         );
     }
 

--- a/classes/package/package_version.php
+++ b/classes/package/package_version.php
@@ -29,7 +29,6 @@ use qtype_questionpy\array_converter\array_converter;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class package_version {
-
     /**
      * @var int package version id
      */

--- a/classes/package_file_service.php
+++ b/classes/package_file_service.php
@@ -29,7 +29,6 @@ use stored_file;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class package_file_service {
-
     /**
      * Get a draft {@see stored_file} with the given ID.
      *
@@ -44,8 +43,12 @@ class package_file_service {
 
         $fs = get_file_storage();
         $files = $fs->get_area_files(
-            $usercontext->id, 'user', 'draft', $draftid,
-            'itemid, filepath, filename', false
+            $usercontext->id,
+            'user',
+            'draft',
+            $draftid,
+            'itemid, filepath, filename',
+            false
         );
         if (!$files) {
             throw new coding_exception("draft file with id '$draftid' does not exist");
@@ -64,8 +67,12 @@ class package_file_service {
     public function get_file(int $qpyid, int $contextid): stored_file {
         $fs = get_file_storage();
         $files = $fs->get_area_files(
-            $contextid, 'qtype_questionpy', 'package', $qpyid,
-            'itemid, filepath, filename', false
+            $contextid,
+            'qtype_questionpy',
+            'package',
+            $qpyid,
+            'itemid, filepath, filename',
+            false
         );
         if (!$files) {
             throw new coding_exception("package file with qpy id '$qpyid' does not exist");

--- a/classes/package_settings.php
+++ b/classes/package_settings.php
@@ -28,15 +28,18 @@ use moodle_exception;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class package_settings extends admin_setting {
-
     /**
      * Constructor for custom package settings.
      */
     public function __construct() {
         $this->nosave = true;
         $this->plugin = 'qtype_questionpy';
-        parent::__construct('qtype_questionpy/persist_packages', new lang_string('packages_subheading', 'qtype_questionpy'),
-            null, null);
+        parent::__construct(
+            'qtype_questionpy/persist_packages',
+            new lang_string('packages_subheading', 'qtype_questionpy'),
+            null,
+            null
+        );
     }
 
     /**

--- a/classes/question_metadata.php
+++ b/classes/question_metadata.php
@@ -25,7 +25,6 @@ namespace qtype_questionpy;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class question_metadata {
-
     /**
      * @var array|null if known, an array of `name => correct_value` entries for the expected response fields
      * @see \qtype_renderer::correct_response()
@@ -54,7 +53,7 @@ class question_metadata {
      * @param string[] $requiredfields an array of required field names
      */
     public function __construct(?array $correctresponse = null, array $expecteddata = [],
-                                array  $requiredfields = []) {
+                                array $requiredfields = []) {
         $this->correctresponse = $correctresponse;
         $this->expecteddata = $expecteddata;
         $this->requiredfields = $requiredfields;

--- a/classes/question_service.php
+++ b/classes/question_service.php
@@ -31,7 +31,6 @@ use stdClass;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class question_service {
-
     /** @var api */
     private api $api;
 
@@ -72,8 +71,14 @@ class question_service {
         if ($record->islocal) {
             // Package was uploaded.
             $filestorage = get_file_storage();
-            $files = $filestorage->get_area_files($PAGE->context->get_course_context()->id, 'qtype_questionpy',
-                'package', $record->id, 'itemid, filepath, filename', false);
+            $files = $filestorage->get_area_files(
+                $PAGE->context->get_course_context()->id,
+                'qtype_questionpy',
+                'package',
+                $record->id,
+                'itemid, filepath, filename',
+                false
+            );
             if (count($files) === 0) {
                 throw new \coding_exception(
                     "No local package version file with hash '{$record->pkgversionhash}' was found despite being referenced" .
@@ -128,7 +133,9 @@ class question_service {
             $pkgversionid = $this->get_package($question->qpy_package_hash);
             if (!$pkgversionid) {
                 throw new moodle_exception(
-                    'package_not_found', 'qtype_questionpy', '',
+                    'package_not_found',
+                    'qtype_questionpy',
+                    '',
                     (object)['packagehash' => $question->qpy_package_hash]
                 );
             }
@@ -179,8 +186,13 @@ class question_service {
                     ], $file);
                 } else {
                     // Get draft file and store the file.
-                    file_save_draft_area_files($question->qpy_package_file, $question->context->id,
-                        'qtype_questionpy', 'package', $questionid);
+                    file_save_draft_area_files(
+                        $question->qpy_package_file,
+                        $question->context->id,
+                        'qtype_questionpy',
+                        'package',
+                        $questionid
+                    );
                 }
             }
         }

--- a/classes/question_ui_renderer.php
+++ b/classes/question_ui_renderer.php
@@ -38,7 +38,6 @@ use question_display_options;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class question_ui_renderer {
-
     /** @var string XML namespace for XHTML */
     public const XHTML_NAMESPACE = "http://www.w3.org/1999/xhtml";
     /** @var string XML namespace for our custom things */
@@ -175,10 +174,12 @@ class question_ui_renderer {
             }
 
             /** @var DOMElement $element */
-            foreach ($xpath->query(
-                "/qpy:question/qpy:formulation
+            foreach (
+                $xpath->query(
+                    "/qpy:question/qpy:formulation
                 //*[self::xhtml:input or self::xhtml:select or self::xhtml:textarea or self::xhtml:button]"
-            ) as $element) {
+                ) as $element
+            ) {
                 $name = $element->getAttribute("name");
                 if ($name) {
                     $this->metadata->expecteddata[$name] = PARAM_RAW;
@@ -252,8 +253,10 @@ class question_ui_renderer {
         foreach (iterator_to_array($xpath->query("//*[@qpy:feedback]")) as $element) {
             $feedback = $element->getAttributeNS(self::QPY_NAMESPACE, "feedback");
 
-            if (($feedback == "general" && !$options->generalfeedback)
-                || ($feedback == "specific" && !$options->feedback)) {
+            if (
+                ($feedback == "general" && !$options->generalfeedback)
+                || ($feedback == "specific" && !$options->feedback)
+            ) {
                 $element->parentNode->removeChild($element);
             }
         }
@@ -313,8 +316,10 @@ class question_ui_renderer {
         /** @var DOMElement $indexelement */
         foreach (iterator_to_array($xpath->query(".//qpy:shuffled-index", $element)) as $indexelement) {
             // phpcs:ignore Squiz.ControlStructures.ForLoopDeclaration.SpacingAfterSecond
-            for ($ancestor = $indexelement->parentNode; $ancestor !== null && $ancestor !== $indexelement;
-                 $ancestor = $ancestor->parentNode) {
+            for (
+                $ancestor = $indexelement->parentNode; $ancestor !== null && $ancestor !== $indexelement;
+                 $ancestor = $ancestor->parentNode
+            ) {
                 assert($ancestor instanceof DOMElement);
                 if ($ancestor->hasAttributeNS(self::QPY_NAMESPACE, "shuffle-contents")) {
                     // The index element is in a nested shuffle-contents.
@@ -357,12 +362,14 @@ class question_ui_renderer {
      */
     private function mangle_ids_and_names(\DOMXPath $xpath, question_attempt $qa): void {
         /** @var DOMAttr $attr */
-        foreach ($xpath->query("
+        foreach (
+            $xpath->query("
                 //xhtml:*/@id | //xhtml:label/@for | //xhtml:output/@for | //xhtml:input/@list |
                 (//xhtml:button | //xhtml:form | //xhtml:fieldset | //xhtml:iframe | //xhtml:input | //xhtml:object |
                  //xhtml:output | //xhtml:select | //xhtml:textarea | //xhtml:map)/@name |
                 //xhtml:img/@usemap
-                ") as $attr) {
+                ") as $attr
+        ) {
             $original = $attr->value;
             if ($attr->name === "usemap" && utils::str_starts_with($original, "#")) {
                 // See https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/useMap.
@@ -386,7 +393,7 @@ class question_ui_renderer {
      * @param question_display_options $options
      * @return void
      */
-    private function set_input_values_and_readonly(DOMXPath                 $xpath, question_attempt $qa,
+    private function set_input_values_and_readonly(DOMXPath $xpath, question_attempt $qa,
                                                    question_display_options $options): void {
         /** @var DOMElement $element */
         foreach ($xpath->query("//xhtml:button | //xhtml:input | //xhtml:select | //xhtml:textarea") as $element) {
@@ -543,16 +550,20 @@ class question_ui_renderer {
      */
     private function add_styles(DOMXPath $xpath): void {
         /** @var DOMElement $element */
-        foreach ($xpath->query("
+        foreach (
+            $xpath->query("
                 //xhtml:input[@type != 'checkbox' and @type != 'radio' and
                               @type != 'button' and @type != 'submit' and @type != 'reset']
                 | //xhtml:select | //xhtml:textarea
-                ") as $element) {
+                ") as $element
+        ) {
             $this->add_class_names($element, "form-control", "qpy-input");
         }
 
-        foreach ($xpath->query("//xhtml:input[@type = 'button' or @type = 'submit' or @type = 'reset']
-                                | //xhtml:button") as $element) {
+        foreach (
+            $xpath->query("//xhtml:input[@type = 'button' or @type = 'submit' or @type = 'reset']
+                                | //xhtml:button") as $element
+        ) {
             $this->add_class_names($element, "btn", "btn-primary", "qpy-input");
         }
 
@@ -600,10 +611,12 @@ class question_ui_renderer {
             $isscorer = has_capability("mod/quiz:grade", $options->context);
             $isdeveloper = $isteacher && debugging();
 
-            if (!(in_array("teacher", $allowedroles) && $isteacher
+            if (
+                !(in_array("teacher", $allowedroles) && $isteacher
                 || in_array("proctor", $allowedroles) && $isteacher
                 || in_array("scorer", $allowedroles) && $isscorer
-                || in_array("developer", $allowedroles) && $isdeveloper)) {
+                || in_array("developer", $allowedroles) && $isdeveloper)
+            ) {
                 $attr->ownerElement->parentNode->removeChild($attr->ownerElement);
             }
         }

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -27,7 +27,6 @@ use qtype_questionpy\form\elements\repetition_element;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class utils {
-
     /**
      * Returns `$array[$key]` after setting it to a new array if it does not exist.
      *

--- a/edit_questionpy_form.php
+++ b/edit_questionpy_form.php
@@ -38,7 +38,6 @@ use qtype_questionpy\package_file_service;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class qtype_questionpy_edit_form extends question_edit_form {
-
     /** @var array current form data set in {@see definition_inner} and added to the question in {@see set_data}. */
     private array $currentdata = [];
 
@@ -72,7 +71,10 @@ class qtype_questionpy_edit_form extends question_edit_form {
 
         $maxkb = get_config('qtype_questionpy', 'max_package_size_kb');
         $mform->addElement(
-            'filepicker', 'qpy_package_file', null, null,
+            'filepicker',
+            'qpy_package_file',
+            null,
+            null,
             ['maxbytes' => $maxkb * 1024, 'accepted_types' => ['.qpy']]
         );
         $mform->hideIf('qpy_package_file', 'qpy_package_source', 'neq', 'upload');
@@ -91,8 +93,10 @@ class qtype_questionpy_edit_form extends question_edit_form {
 
         // Create a group which contains the package container - the group is used to simplify the styling.
         // TODO: get limit from settings.
-        $group[] = $mform->createElement('html', $OUTPUT->render_from_template('qtype_questionpy/package_search/area',
-            ['contextid' => $this->context->get_course_context()->id, 'limit' => 10]));
+        $group[] = $mform->createElement('html', $OUTPUT->render_from_template(
+            'qtype_questionpy/package_search/area',
+            ['contextid' => $this->context->get_course_context()->id, 'limit' => 10]
+        ));
         $mform->addGroup($group, 'qpy_package_container');
         $mform->hideIf('qpy_package_container', 'qpy_package_source', 'neq', 'search');
     }
@@ -124,7 +128,8 @@ class qtype_questionpy_edit_form extends question_edit_form {
 
         $group = [];
         $group[] = $mform->createElement(
-            'html', $OUTPUT->render_from_template('qtype_questionpy/package/package_selection', $packagearray)
+            'html',
+            $OUTPUT->render_from_template('qtype_questionpy/package/package_selection', $packagearray)
         );
         $mform->addGroup($group, '', get_string('selection_title_selected', 'qtype_questionpy'));
 
@@ -224,18 +229,26 @@ class qtype_questionpy_edit_form extends question_edit_form {
             // View package search container and file picker.
             $searchorupload = [
                 $mform->createElement(
-                    'radio', 'qpy_package_source', null,
-                    get_string('question_package_search', 'qtype_questionpy'), 'search'
+                    'radio',
+                    'qpy_package_source',
+                    null,
+                    get_string('question_package_search', 'qtype_questionpy'),
+                    'search'
                 ),
                 $mform->createElement(
-                    'radio', 'qpy_package_source', null,
-                    get_string('question_package_upload', 'qtype_questionpy'), 'upload'
+                    'radio',
+                    'qpy_package_source',
+                    null,
+                    get_string('question_package_upload', 'qtype_questionpy'),
+                    'upload'
                 ),
             ];
             $mform->addGroup(
-                $searchorupload, 'qpy_package_source_group',
+                $searchorupload,
+                'qpy_package_source_group',
                 get_string('selection_title', 'qtype_questionpy'),
-                null, false
+                null,
+                false
             );
             $mform->setDefault('qpy_package_source', 'search');
             $mform->addRule('qpy_package_source_group', null, 'required');

--- a/lib.php
+++ b/lib.php
@@ -35,7 +35,7 @@
  * @param array $options additional options affecting the file serving
  * @return bool
  */
-function qtype_questionpy_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options=[]) {
+function qtype_questionpy_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options = []) {
     global $CFG;
     require_once($CFG->libdir . '/questionlib.php');
     question_pluginfile($course, $context, 'qtype_questionpy', $filearea, $args, $forcedownload, $options);

--- a/question.php
+++ b/question.php
@@ -32,7 +32,6 @@ use qtype_questionpy\question_ui_renderer;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class qtype_questionpy_question extends question_graded_automatically_with_countback {
-
     /** @var string */
     private const QT_VAR_ATTEMPT_STATE = "_attemptstate";
     /** @var string */
@@ -124,8 +123,11 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
         $this->scoringstate = $step->get_qt_var(self::QT_VAR_SCORING_STATE);
 
         // TODO: We probably want to pass the last response here, but don't have an obvious way to get it.
-        $attempt = $this->api->package($this->packagehash, $this->packagefile)->view_attempt($this->questionstate,
-            $this->attemptstate, $this->scoringstate);
+        $attempt = $this->api->package($this->packagehash, $this->packagefile)->view_attempt(
+            $this->questionstate,
+            $this->attemptstate,
+            $this->scoringstate
+        );
         $this->ui = new question_ui_renderer($attempt->ui->content, $attempt->ui->placeholders);
     }
 
@@ -222,8 +224,12 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
      * @throws moodle_exception
      */
     public function grade_response(array $response): array {
-        $attemptscored = $this->api->package($this->packagehash, $this->packagefile)->score_attempt($this->questionstate,
-            $this->attemptstate, $this->scoringstate, $response);
+        $attemptscored = $this->api->package($this->packagehash, $this->packagefile)->score_attempt(
+            $this->questionstate,
+            $this->attemptstate,
+            $this->scoringstate,
+            $response
+        );
         $this->ui = new question_ui_renderer($attemptscored->ui->content, $attemptscored->ui->placeholders);
         // TODO: Persist scoring state. We need to set a qtvar, but we don't have access to the pending step here.
         $this->scoringstate = $attemptscored->scoringstate;

--- a/renderer.php
+++ b/renderer.php
@@ -29,7 +29,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class qtype_questionpy_renderer extends qtype_renderer {
-
     /**
      * Return any HTML that needs to be included in the page's <head> when this
      * question is used.
@@ -79,8 +78,11 @@ class qtype_questionpy_renderer extends qtype_renderer {
         $hint = null;
 
         if ($options->feedback) {
-            $output .= html_writer::nonempty_tag('div', $question->ui->render_specific_feedback($qa, $options) ?? "",
-                ['class' => 'specificfeedback']);
+            $output .= html_writer::nonempty_tag(
+                'div',
+                $question->ui->render_specific_feedback($qa, $options) ?? "",
+                ['class' => 'specificfeedback']
+            );
             $hint = $qa->get_applicable_hint();
         }
 
@@ -93,13 +95,19 @@ class qtype_questionpy_renderer extends qtype_renderer {
         }
 
         if ($options->generalfeedback) {
-            $output .= html_writer::nonempty_tag('div', $question->ui->render_general_feedback($qa, $options) ?? "",
-                ['class' => 'generalfeedback']);
+            $output .= html_writer::nonempty_tag(
+                'div',
+                $question->ui->render_general_feedback($qa, $options) ?? "",
+                ['class' => 'generalfeedback']
+            );
         }
 
         if ($options->rightanswer) {
-            $output .= html_writer::nonempty_tag('div', $question->ui->render_right_answer($qa, $options) ?? "",
-                ['class' => 'rightanswer']);
+            $output .= html_writer::nonempty_tag(
+                'div',
+                $question->ui->render_right_answer($qa, $options) ?? "",
+                ['class' => 'rightanswer']
+            );
         }
 
         return $output;

--- a/settings.php
+++ b/settings.php
@@ -27,7 +27,6 @@ defined('MOODLE_INTERNAL') || die();
 use qtype_questionpy\package_settings;
 
 if ($ADMIN->fulltree) {
-
     // General server settings.
     $settings->add(new admin_setting_configtext(
         'qtype_questionpy/server_url',
@@ -79,4 +78,3 @@ if ($ADMIN->fulltree) {
         ])
     ));
 }
-

--- a/tests/data_provider.php
+++ b/tests/data_provider.php
@@ -105,9 +105,13 @@ function element_provider(): array {
         ],
         ["checkbox_group", new checkbox_group_element(
             (new checkbox_element(
-                "my_checkbox", "Left", "Right",
-                true, true
-            ))->help("Help text")),
+                "my_checkbox",
+                "Left",
+                "Right",
+                true,
+                true
+            ))->help("Help text")
+        ),
         ],
         ["group", (new group_element("my_group", "Name", [
             new text_input_element("first_name", "", true, null, "Vorname"),

--- a/tests/external/favourite_package_test.php
+++ b/tests/external/favourite_package_test.php
@@ -46,7 +46,6 @@ require_once($CFG->dirroot . '/webservice/tests/helpers.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class favourite_package_test extends \externallib_advanced_testcase {
-
     /**
      * This method is called before each test.
      */

--- a/tests/external/search_packages_test.php
+++ b/tests/external/search_packages_test.php
@@ -48,7 +48,6 @@ require_once($CFG->dirroot . '/webservice/tests/helpers.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class search_packages_test extends \externallib_advanced_testcase {
-
     /**
      * This method is called before each test.
      */

--- a/tests/http_response_container_test.php
+++ b/tests/http_response_container_test.php
@@ -27,7 +27,6 @@ use qtype_questionpy\api\http_response_container;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class http_response_container_test extends \advanced_testcase {
-
     /**
      * Tests the function get_data with json.
      *
@@ -75,5 +74,4 @@ class http_response_container_test extends \advanced_testcase {
         self::expectException(moodle_exception::class);
         $response->get_data();
     }
-
 }

--- a/tests/localizer_test.php
+++ b/tests/localizer_test.php
@@ -24,7 +24,6 @@ namespace qtype_questionpy;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class localizer_test extends \advanced_testcase {
-
     /**
      * Test the default of the function get_preferred_language.
      *

--- a/tests/package/package_base_test.php
+++ b/tests/package/package_base_test.php
@@ -24,7 +24,6 @@ namespace qtype_questionpy\package;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class package_base_test extends \advanced_testcase {
-
     /**
      * Tests the method get_localized_name.
      *
@@ -61,8 +60,16 @@ class package_base_test extends \advanced_testcase {
      */
     public function test_get_localized_description(): void {
         $description = ['en' => 'english_description', 'de' => 'german_description', 'fr' => 'french_description'];
-        $package = new package_base('shortname', 'default', ['en' => 'english_name'],
-            'question', 'author', 'url', [], $description);
+        $package = new package_base(
+            'shortname',
+            'default',
+            ['en' => 'english_name'],
+            'question',
+            'author',
+            'url',
+            [],
+            $description
+        );
 
         // Every language in package exists in preferred language.
         $languages = ['en', 'de', 'fr'];
@@ -78,20 +85,44 @@ class package_base_test extends \advanced_testcase {
 
         // Preferred language and fallback language in package does not exist.
         $description = ['de' => 'german_description', 'fr' => 'french_description'];
-        $package = new package_base('shortname', 'default', ['en' => 'english_name'],
-            'question', 'author', 'url', [], $description);
+        $package = new package_base(
+            'shortname',
+            'default',
+            ['en' => 'english_name'],
+            'question',
+            'author',
+            'url',
+            [],
+            $description
+        );
         $this->assertEquals($description['de'], $package->get_localized_description($languages));
 
         // Description is empty.
         $description = [];
-        $package = new package_base('shortname', 'default', ['en' => 'english_name'],
-            'question', 'author', 'url', [], $description);
+        $package = new package_base(
+            'shortname',
+            'default',
+            ['en' => 'english_name'],
+            'question',
+            'author',
+            'url',
+            [],
+            $description
+        );
         $this->assertEquals('', $package->get_localized_description($languages));
 
         // Description is not set.
         $description = null;
-        $package = new package_base('shortname', 'default', ['en' => 'english_name'],
-            'question', 'author', 'url', [], $description);
+        $package = new package_base(
+            'shortname',
+            'default',
+            ['en' => 'english_name'],
+            'question',
+            'author',
+            'url',
+            [],
+            $description
+        );
         $this->assertEquals('', $package->get_localized_description($languages));
     }
 }

--- a/tests/package/package_raw_test.php
+++ b/tests/package/package_raw_test.php
@@ -32,7 +32,6 @@ require_once(dirname(__DIR__) . '/data_provider.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class package_raw_test extends \advanced_testcase {
-
     /**
      * Provides valid package data.
      *

--- a/tests/package/package_test.php
+++ b/tests/package/package_test.php
@@ -31,7 +31,6 @@ require_once(dirname(__DIR__) . '/data_provider.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class package_test extends \advanced_testcase {
-
     /**
      * Tests the method get_by_version.
      *

--- a/tests/package/package_version_test.php
+++ b/tests/package/package_version_test.php
@@ -32,7 +32,6 @@ require_once(dirname(__DIR__) . '/data_provider.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class package_version_test extends \advanced_testcase {
-
     /**
      * Tests the get_by_id method.
      *

--- a/tests/question_service_test.php
+++ b/tests/question_service_test.php
@@ -33,7 +33,6 @@ use stdClass;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class question_service_test extends \advanced_testcase {
-
     /** @var api */
     private api $api;
 
@@ -76,7 +75,8 @@ class question_service_test extends \advanced_testcase {
                 "qpy_package_hash" => $package->hash,
                 "qpy_state" => $statestr,
                 "qpy_is_local" => "0",
-            ], $result
+            ],
+            $result
         );
     }
 

--- a/tests/question_type_test.php
+++ b/tests/question_type_test.php
@@ -24,8 +24,6 @@ namespace qtype_questionpy;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class question_type_test extends \advanced_testcase {
-
-
     /**
      * Dummy Test (replace when we have real methods testing the question type).
      *

--- a/tests/question_ui_renderer_test.php
+++ b/tests/question_ui_renderer_test.php
@@ -28,7 +28,6 @@ use DOMException;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class question_ui_renderer_test extends \advanced_testcase {
-
     /**
      * Tests that metadata is correctly extracted from the UI's input elements.
      *


### PR DESCRIPTION
Closes #110.

Mit der Regel `PSR2.Methods.FunctionCallSignature.MultipleArguments` müssen die Argumente von **mehrzeiligen** Funktionsaufrufen jeweils in ihrer eigenen Zeile sein - ich finde das nicht tragisch, kann aber natürlich auch exkludiert werden.

Es ist auch möglich [Regelverstöße per Kommentar zu ignorieren](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-parts-of-a-file), z.B. mit `// phpcs:ignore` oder `// phpcs:ignore PSR2.Methods.FunctionCallSignature.MultipleArguments`.