### PR TITLE
Moodle 4.4

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -35,15 +35,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.4', '8.0', '8.1' ]
-        moodle-branch: [ 'MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE' ]
+        php: [ '8.1', '8.2', '8.3' ]
+        moodle-branch: [ 'MOODLE_404_STABLE' ]
         database: [ pgsql, mariadb ]
-        exclude:
-          # Moodle >=4.2 requires PHP >=8.0.
-          - moodle-branch: MOODLE_402_STABLE
-            php: 7.4
-          - moodle-branch: MOODLE_403_STABLE
-            php: 7.4
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Moodle Code Checker
         if: ${{ !cancelled() }}
-        run: moodle-plugin-ci phpcs --standard moodle-extra --exclude moodle.Commenting.TodoComment,Squiz.Functions.MultiLineFunctionDeclaration --max-warnings 0
+        run: moodle-plugin-ci phpcs --standard ./phpcs.xml --max-warnings 0
 
       - name: Moodle PHPDoc Checker
         if: ${{ !cancelled() }}

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -73,11 +73,6 @@ jobs:
         if: ${{ !cancelled() }}
         run: moodle-plugin-ci phplint
 
-      - name: PHP Copy/Paste Detector
-        continue-on-error: true # This step will show errors but will not fail
-        if: ${{ !cancelled() }}
-        run: moodle-plugin-ci phpcpd
-
       - name: PHP Mess Detector
         continue-on-error: true # This step will show errors but will not fail
         if: ${{ !cancelled() }}
@@ -112,8 +107,18 @@ jobs:
         run: moodle-plugin-ci phpunit --fail-on-warning
 
       - name: Behat features
+        id: behat
         if: ${{ !cancelled() }}
         run: moodle-plugin-ci behat --profile chrome
+
+      - name: Upload Behat Faildump
+        if: ${{ failure() && steps.behat.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Behat Faildump (${{ join(matrix.*, ', ') }})
+          path: ${{ github.workspace }}/moodledata/behat_dump
+          retention-days: 7
+          if-no-files-found: ignore
 
       - name: Mark cancelled jobs as failed.
         if: ${{ cancelled() }}

--- a/lang/en/qtype_questionpy.php
+++ b/lang/en/qtype_questionpy.php
@@ -22,87 +22,69 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+$string['change_package'] = 'Change';
+$string['curl_exec_error'] = 'Error while fetching from server. Error number: {$a}';
+$string['curl_init_error'] = 'Could not initialize cURL. Error number: {$a}';
+$string['curl_set_opt_error'] = 'Failed to set cURL option. Error number: {$a}';
+$string['form_fallback_element_text'] = "The QuestionPy package is using a form element not supported by the Moodle"
+    . " plugin. Please ensure you are using a compatible package or contact your administrators.";
+$string['formerror_noqpy_package'] = 'Selected file must be of type .qpy';
+$string['json_parsing_error'] = 'Could not parse data to JSON.';
+$string['load_packages_button'] = 'Load Packages';
+$string['mark_as_favourite'] = 'Favourite';
+$string['max_package_size_kb'] = 'Maximum file size of a QuestionPy package';
+$string['max_package_size_kb_description'] = 'Maximum file size in kB';
+$string['open_website'] = 'Open website';
+$string['package_not_found'] = 'The requested package {$a->packagehash} does not exist.';
+$string['packages_subheading'] = 'Packages';
 $string['pluginname'] = 'QuestionPy';
 $string['pluginname_help'] = 'Create own question types in Python.';
 $string['pluginnameadding'] = 'Adding a QuestionPy question';
 $string['pluginnameediting'] = 'Editing a QuestionPy question';
 $string['pluginnamesummary'] = 'A comprehensive question type that allows you to create own question types in Python.';
-
-// Application server settings.
-$string['server_url'] = 'QuestionPy Application Server URL';
+$string['question_package_search'] = 'Select an existing package';
+$string['question_package_upload'] = 'Upload your own';
+$string['remove_packages_button'] = 'Remove Packages';
+$string['same_version_different_hash_error'] = 'A package with the same version but different hash already exists.';
+$string['search_all_header'] = 'All ({$a})';
+$string['search_bar'] = 'Search...';
+$string['search_bar_label_aria'] = 'Search Bar';
+$string['search_favourites_header'] = 'Favourites ({$a})';
+$string['search_pagination_label_aria'] = 'Search results pages';
+$string['search_pagination_next_aria'] = 'Next';
+$string['search_pagination_previous_aria'] = 'Previous';
+$string['search_recentlyused_header'] = 'Recently Used ({$a})';
+$string['search_sort_alphabetical'] = 'Alphabetical';
+$string['search_sort_creation_date'] = 'Creation Date';
+$string['search_sort_label_aria'] = 'Sorting';
+$string['select_package'] = 'Select';
+$string['select_package_element_aria'] = 'Choose version.';
+$string['selection_custom_package_header'] = 'Custom Package';
+$string['selection_custom_package_text'] = 'This package was uploaded by a user and might not appear in the package search.';
+$string['selection_no_icon'] = 'Could not load the icon.';
+$string['selection_required'] = 'Please select a package.';
+$string['selection_title'] = 'Select QuestionPy Package';
+$string['selection_title_selected'] = 'Selected Package';
+$string['server_bad_status'] = 'The QuestionPy server could not successfully complete our request. Status code: {$a}';
+$string['server_info_allow_lms_packages'] = 'Allows packages from the LMS';
+$string['server_info_description'] = '<a href="{$a->link}">Information</a> about the application server you are connected to.';
+$string['server_info_heading'] = 'QuestionPy Application Server Information';
+$string['server_info_max_package_size'] = 'Maximum package size';
+$string['server_info_name'] = 'Name';
+$string['server_info_requests_in_process'] = 'Requests in process';
+$string['server_info_requests_in_queue'] = 'Requests in queue';
+$string['server_info_title_general'] = 'General';
+$string['server_info_usage_title'] = 'Usage';
+$string['server_info_version'] = 'Version';
 $string['server_password'] = 'QuestionPy Application Server Password';
 $string['server_password_description'] = 'The Password to access the Application Server';
 $string['server_timeout'] = 'Server timeout time';
 $string['server_timeout_description'] = 'Server timeout time in seconds';
-$string['max_package_size_kb'] = 'Maximum file size of a QuestionPy package';
-$string['max_package_size_kb_description'] = 'Maximum file size in kB';
-$string['packages_subheading'] = 'Packages';
-$string['total_packages'] = '{$a->packages} packages with a total of {$a->versions} versions';
-$string['load_packages_button'] = 'Load Packages';
-$string['remove_packages_button'] = 'Remove Packages';
+$string['server_url'] = 'QuestionPy Application Server URL';
 $string['service_failed'] = 'Failed.';
-$string['server_info_heading'] = 'QuestionPy Application Server Information';
-$string['server_info_description'] = '<a href="{$a->link}">Information</a> about the application server you are connected to.';
-$string['server_info_title_general'] = 'General';
-$string['server_info_name'] = 'Name';
-$string['server_info_version'] = 'Version';
-$string['server_info_allow_lms_packages'] = 'Allows packages from the LMS';
-$string['server_info_max_package_size'] = 'Maximum package size';
-$string['server_info_usage_title'] = 'Usage';
-$string['server_info_requests_in_process'] = 'Requests in process';
-$string['server_info_requests_in_queue'] = 'Requests in queue';
-
-// Package upload.
-$string['formerror_noqpy_package'] = 'Selected file must be of type .qpy';
-$string['same_version_different_hash_error'] = 'A package with the same version but different hash already exists.';
-$string['version_is_already_stored_error'] = 'The package version was already stored by the current user.';
-
-// Package selection.
-$string['selection_title'] = 'Select QuestionPy Package';
-$string['selection_title_selected'] = 'Selected Package';
-$string['selection_no_icon'] = 'Could not load the icon.';
-$string['selection_required'] = 'Please select a package.';
-
-$string['selection_custom_package_header'] = 'Custom Package';
-$string['selection_custom_package_text'] = 'This package was uploaded by a user and might not appear in the package search.';
-
-$string['select_package'] = 'Select';
-$string['select_package_element_aria'] = 'Choose version.';
-$string['change_package'] = 'Change';
-
-$string['open_website'] = 'Open website';
-$string['mark_as_favourite'] = 'Favourite';
-$string['unmark_as_favourite'] = 'Favourite';
-
-// Package search.
-$string['search_bar'] = 'Search...';
-$string['search_bar_label_aria'] = 'Search Bar';
 $string['tag_bar'] = 'Tags...';
 $string['tag_bar_label_aria'] = 'Tags';
 $string['tag_bar_no_selection'] = '';
-$string['search_all_header'] = 'All ({$a})';
-$string['search_recentlyused_header'] = 'Recently Used ({$a})';
-$string['search_favourites_header'] = 'Favourites ({$a})';
-$string['search_pagination_label_aria'] = 'Search results pages';
-$string['search_pagination_previous_aria'] = 'Previous';
-$string['search_pagination_next_aria'] = 'Next';
-$string['search_sort_label_aria'] = 'Sorting';
-$string['search_sort_alphabetical'] = 'Alphabetical';
-$string['search_sort_creation_date'] = 'Creation Date';
-
-$string['question_package_search'] = 'Select an existing package';
-$string['question_package_upload'] = 'Upload your own';
-
-// Package options form.
-$string['form_fallback_element_text'] = "The QuestionPy package is using a form element not supported by the Moodle"
-    . " plugin. Please ensure you are using a compatible package or contact your administrators.";
-
-// Question management.
-$string['package_not_found'] = 'The requested package {$a->packagehash} does not exist.';
-
-// Connector.
-$string['curl_init_error'] = 'Could not initialize cURL. Error number: {$a}';
-$string['curl_exec_error'] = 'Error while fetching from server. Error number: {$a}';
-$string['curl_set_opt_error'] = 'Failed to set cURL option. Error number: {$a}';
-$string['json_parsing_error'] = 'Could not parse data to JSON.';
-$string['server_bad_status'] = 'The QuestionPy server could not successfully complete our request. Status code: {$a}';
+$string['total_packages'] = '{$a->packages} packages with a total of {$a->versions} versions';
+$string['unmark_as_favourite'] = 'Favourite';
+$string['version_is_already_stored_error'] = 'The package version was already stored by the current user.';

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="QuestionPy">
+    <rule ref="moodle-extra">
+        <exclude name="moodle.Commenting.TodoComment"/>
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration"/>
+    </rule>
+</ruleset>

--- a/tests/external/favourite_package_test.php
+++ b/tests/external/favourite_package_test.php
@@ -45,7 +45,7 @@ require_once($CFG->dirroot . '/webservice/tests/helpers.php');
  * @copyright  2024 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class favourite_package_test extends \externallib_advanced_testcase {
+final class favourite_package_test extends \externallib_advanced_testcase {
     /**
      * This method is called before each test.
      */

--- a/tests/external/get_tags_test.php
+++ b/tests/external/get_tags_test.php
@@ -44,7 +44,7 @@ require_once($CFG->dirroot . '/webservice/tests/helpers.php');
  * @copyright  2024 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class get_tags_test extends \externallib_advanced_testcase {
+final class get_tags_test extends \externallib_advanced_testcase {
     /**
      * Test that the user needs to be logged in.
      *

--- a/tests/external/search_packages_test.php
+++ b/tests/external/search_packages_test.php
@@ -47,7 +47,7 @@ require_once($CFG->dirroot . '/webservice/tests/helpers.php');
  * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class search_packages_test extends \externallib_advanced_testcase {
+final class search_packages_test extends \externallib_advanced_testcase {
     /**
      * This method is called before each test.
      */
@@ -839,7 +839,7 @@ class search_packages_test extends \externallib_advanced_testcase {
      * @return void
      * @throws moodle_exception
      */
-    public function test_search_with_tags() {
+    public function test_search_with_tags(): void {
         global $DB;
 
         package_provider(['namespace' => 'ns1', 'tags' => ['a']])->store();

--- a/tests/form/elements/element_html_test.php
+++ b/tests/form/elements/element_html_test.php
@@ -51,11 +51,6 @@ class element_html_test extends \advanced_testcase {
      * @covers       \qtype_questionpy\form\qpy_renderable
      */
     public function test_rendered_html_should_match_snapshot(string $elementkind, qpy_renderable $element): void {
-        global $CFG;
-        if ($CFG->branch < "403") {
-            $this->markTestSkipped("Mform HTML output changes between Moodle versions so we only run them on 4.3");
-        }
-
         $snapshotfilepath = __DIR__ . "/html/" . $elementkind . ".html";
 
         // The sesskey is part of the form and therefore needs to be deterministic.

--- a/tests/form/elements/element_html_test.php
+++ b/tests/form/elements/element_html_test.php
@@ -32,7 +32,7 @@ use function qtype_questionpy\element_provider;
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class element_html_test extends \advanced_testcase {
+final class element_html_test extends \advanced_testcase {
     /**
      * Implements a snapshot testing approach similar to that of {@link https://jestjs.io/docs/snapshot-testing Jest}.
      *

--- a/tests/form/elements/element_json_test.php
+++ b/tests/form/elements/element_json_test.php
@@ -31,7 +31,7 @@ use function qtype_questionpy\element_provider;
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class element_json_test extends \advanced_testcase {
+final class element_json_test extends \advanced_testcase {
     /**
      * Serializes values and compares resulting JSON to an expected file.
      *

--- a/tests/form/elements/html/checkbox.html
+++ b/tests/form/elements/html/checkbox.html
@@ -4,7 +4,7 @@
 <input name="_qf__qtype_questionpy_form_elements_test_moodleform" type="hidden" value="1">
 </div>
 
-<div class="form-group row  fitem   ">
+<div class="mb-3 row  fitem   ">
     <div class="col-md-3 col-form-label pb-0 pt-0">
             <label class="d-inline word-break" for="id_qpy_form_my_checkbox">
                 Left

--- a/tests/form/elements/html/checkbox_group.html
+++ b/tests/form/elements/html/checkbox_group.html
@@ -5,7 +5,7 @@
 <input name="_qf__qtype_questionpy_form_elements_test_moodleform" type="hidden" value="1">
 </div>
 
-<div class="form-group row  fitem  checkboxgroup1 ">
+<div class="mb-3 row  fitem  checkboxgroup1 ">
     <div class="col-md-3 col-form-label pb-0 pt-0">
             <label class="d-inline word-break" for="id_qpy_form_my_checkbox">
                 Left
@@ -31,14 +31,14 @@
             
         </div>
     </div>
-</div><div id="fitem_id_nosubmit_checkbox_controller1" class="form-group row  fitem femptylabel   ">
+</div><div id="fitem_id_nosubmit_checkbox_controller1" class="mb-3 row  fitem femptylabel   ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
         <div class="form-label-addon d-flex align-items-center align-self-start">
             
         </div>
     </div>
-    <div class="col-md-9 form-inline align-items-start felement" data-fieldtype="submit">
+    <div class="col-md-9 d-flex flex-wrap align-items-start felement" data-fieldtype="submit">
             <input type="submit" class="btn
                         btn-primary
                         

--- a/tests/form/elements/html/group.html
+++ b/tests/form/elements/html/group.html
@@ -4,7 +4,7 @@
 <input name="_qf__qtype_questionpy_form_elements_test_moodleform" type="hidden" value="1">
 </div>
 
-<div id="fgroup_id_qpy_form_my_group" class="form-group row  fitem    " data-groupname="qpy_form[my_group]">
+<div id="fgroup_id_qpy_form_my_group" class="mb-3 row  fitem    " data-groupname="qpy_form[my_group]">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
                     <p id="fgroup_id_qpy_form_my_group_label" class="mb-0 word-break" aria-hidden="true">
                 Name
@@ -16,12 +16,12 @@
 </a>
         </div>
     </div>
-    <div class="col-md-9 form-inline align-items-start felement" data-fieldtype="group">
-        <fieldset class="w-100 m-0 p-0 border-0">
+    <div class="col-md-9 d-flex flex-wrap align-items-start felement" data-fieldtype="group">
+            <fieldset class="w-100 m-0 p-0 border-0">
                 <legend class="sr-only">Name</legend>
-            <div class="d-flex flex-wrap align-items-center">
-                
-                <div class="form-group  fitem  ">
+                <div class="d-flex flex-wrap align-items-center">
+                    
+                    <div class="mb-3  fitem  ">
     <span data-fieldtype="text">
     <input type="text" class="form-control " name="qpy_form[my_group][first_name]" id="id_qpy_form_my_group_first_name" value="" placeholder="Vorname">
     </span>
@@ -29,8 +29,8 @@
         
     </div>
 </div>
-                &nbsp;
-                <div class="form-group  fitem  ">
+                    &nbsp;
+                    <div class="mb-3  fitem  ">
     <span data-fieldtype="text">
     <input type="text" class="form-control " name="qpy_form[my_group][last_name]" id="id_qpy_form_my_group_last_name" value="" placeholder="Nachname (optional)">
     </span>
@@ -38,8 +38,8 @@
         
     </div>
 </div>
-            </div>
-        </fieldset>
+                </div>
+            </fieldset>
         <div class="form-control-feedback invalid-feedback" id="fgroup_id_error_qpy_form_my_group">
             
         </div>

--- a/tests/form/elements/html/input.html
+++ b/tests/form/elements/html/input.html
@@ -4,7 +4,7 @@
 <input name="_qf__qtype_questionpy_form_elements_test_moodleform" type="hidden" value="1">
 </div>
 
-<div id="fitem_id_qpy_form_my_field" class="form-group row  fitem    ">
+<div id="fitem_id_qpy_form_my_field" class="mb-3 row  fitem    ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
                 <label id="id_qpy_form_my_field_label" class="d-inline word-break " for="id_qpy_form_my_field">
@@ -18,7 +18,7 @@
             
         </div>
     </div>
-    <div class="col-md-9 form-inline align-items-start felement" data-fieldtype="text">
+    <div class="col-md-9 d-flex flex-wrap align-items-start felement" data-fieldtype="text">
         <input type="text" class="form-control " name="qpy_form[my_field]" id="id_qpy_form_my_field" value="default" aria-required="true" placeholder="placeholder">
         <div class="form-control-feedback invalid-feedback" id="id_error_qpy_form_my_field">
             

--- a/tests/form/elements/html/radio_group.html
+++ b/tests/form/elements/html/radio_group.html
@@ -4,7 +4,7 @@
 <input name="_qf__qtype_questionpy_form_elements_test_moodleform" type="hidden" value="1">
 </div>
 
-<div id="fgroup_id_qpy_form_radio_group_my_radio" class="form-group row  fitem    " data-groupname="qpy_form[radio_group_my_radio]">
+<div id="fgroup_id_qpy_form_radio_group_my_radio" class="mb-3 row  fitem    " data-groupname="qpy_form[radio_group_my_radio]">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
                     <p id="fgroup_id_qpy_form_radio_group_my_radio_label" class="mb-0 word-break" aria-hidden="true">
                 Label
@@ -17,12 +17,12 @@
             
         </div>
     </div>
-    <div class="col-md-9 form-inline align-items-start felement" data-fieldtype="group">
-        <fieldset class="w-100 m-0 p-0 border-0">
+    <div class="col-md-9 d-flex flex-wrap align-items-start felement" data-fieldtype="group">
+            <fieldset class="w-100 m-0 p-0 border-0">
                 <legend class="sr-only">Label</legend>
-            <div class="d-flex flex-wrap align-items-center">
-                
-                <label class="form-check-inline form-check-label  fitem  ">
+                <div class="d-flex flex-wrap align-items-center">
+                    
+                    <label class="form-check-inline form-check-label  fitem  ">
 
 <input type="radio" class="form-check-input " name="qpy_form[my_radio]" id="id_qpy_form_my_radio_opt1" value="opt1" checked>
     Option 1
@@ -31,8 +31,8 @@
 <span class="form-control-feedback invalid-feedback" id="id_error_qpy_form_my_radio_opt1">
     
 </span>
-                &nbsp;
-                <label class="form-check-inline form-check-label  fitem  ">
+                    &nbsp;
+                    <label class="form-check-inline form-check-label  fitem  ">
 
 <input type="radio" class="form-check-input " name="qpy_form[my_radio]" id="id_qpy_form_my_radio_opt2" value="opt2">
     Option 2
@@ -41,8 +41,8 @@
 <span class="form-control-feedback invalid-feedback" id="id_error_qpy_form_my_radio_opt2">
     
 </span>
-            </div>
-        </fieldset>
+                </div>
+            </fieldset>
         <div class="form-control-feedback invalid-feedback" id="fgroup_id_error_qpy_form_radio_group_my_radio">
             
         </div>

--- a/tests/form/elements/html/repetition.html
+++ b/tests/form/elements/html/repetition.html
@@ -5,7 +5,7 @@
 <input name="_qf__qtype_questionpy_form_elements_test_moodleform" type="hidden" value="1">
 </div>
 
-<div class="qpy-repetition"><div class="qpy-repetition-content"><div id="fitem_id_qpy_form_my_rep_0_item" class="form-group row  fitem    ">
+<div class="qpy-repetition"><div class="qpy-repetition-content"><div id="fitem_id_qpy_form_my_rep_0_item" class="mb-3 row  fitem    ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
                 <label id="id_qpy_form_my_rep_0_item_label" class="d-inline word-break " for="id_qpy_form_my_rep_0_item">
@@ -16,13 +16,13 @@
             
         </div>
     </div>
-    <div class="col-md-9 form-inline align-items-start felement" data-fieldtype="text">
+    <div class="col-md-9 d-flex flex-wrap align-items-start felement" data-fieldtype="text">
         <input type="text" class="form-control " name="qpy_form[my_rep][0][item]" id="id_qpy_form_my_rep_0_item" value="">
         <div class="form-control-feedback invalid-feedback" id="id_error_qpy_form_my_rep_0_item">
             
         </div>
     </div>
-</div></div><div class="qpy-repetition-controls"><button name="qpy_repetition[qpy_form_my_rep_][remove][0]" type="submit" class="btn btn-secondary qpy-repetition-remove" value="remove"><i class="icon fa fa-trash fa-fw " title="Remove" role="img" aria-label="Remove"></i> Remove</button></div></div><div class="qpy-repetition"><div class="qpy-repetition-content"><div id="fitem_id_qpy_form_my_rep_1_item" class="form-group row  fitem    ">
+</div></div><div class="qpy-repetition-controls"><button name="qpy_repetition[qpy_form_my_rep_][remove][0]" type="submit" class="btn btn-secondary qpy-repetition-remove" value="remove"><i class="icon fa fa-trash fa-fw " title="Remove" role="img" aria-label="Remove"></i> Remove</button></div></div><div class="qpy-repetition"><div class="qpy-repetition-content"><div id="fitem_id_qpy_form_my_rep_1_item" class="mb-3 row  fitem    ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
                 <label id="id_qpy_form_my_rep_1_item_label" class="d-inline word-break " for="id_qpy_form_my_rep_1_item">
@@ -33,13 +33,13 @@
             
         </div>
     </div>
-    <div class="col-md-9 form-inline align-items-start felement" data-fieldtype="text">
+    <div class="col-md-9 d-flex flex-wrap align-items-start felement" data-fieldtype="text">
         <input type="text" class="form-control " name="qpy_form[my_rep][1][item]" id="id_qpy_form_my_rep_1_item" value="">
         <div class="form-control-feedback invalid-feedback" id="id_error_qpy_form_my_rep_1_item">
             
         </div>
     </div>
-</div></div><div class="qpy-repetition-controls"><button name="qpy_repetition[qpy_form_my_rep_][remove][1]" type="submit" class="btn btn-secondary qpy-repetition-remove" value="remove"><i class="icon fa fa-trash fa-fw " title="Remove" role="img" aria-label="Remove"></i> Remove</button></div></div><div class="qpy-repetition"><div class="qpy-repetition-content"><div id="fitem_id_qpy_form_my_rep_2_item" class="form-group row  fitem    ">
+</div></div><div class="qpy-repetition-controls"><button name="qpy_repetition[qpy_form_my_rep_][remove][1]" type="submit" class="btn btn-secondary qpy-repetition-remove" value="remove"><i class="icon fa fa-trash fa-fw " title="Remove" role="img" aria-label="Remove"></i> Remove</button></div></div><div class="qpy-repetition"><div class="qpy-repetition-content"><div id="fitem_id_qpy_form_my_rep_2_item" class="mb-3 row  fitem    ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
                 <label id="id_qpy_form_my_rep_2_item_label" class="d-inline word-break " for="id_qpy_form_my_rep_2_item">
@@ -50,20 +50,20 @@
             
         </div>
     </div>
-    <div class="col-md-9 form-inline align-items-start felement" data-fieldtype="text">
+    <div class="col-md-9 d-flex flex-wrap align-items-start felement" data-fieldtype="text">
         <input type="text" class="form-control " name="qpy_form[my_rep][2][item]" id="id_qpy_form_my_rep_2_item" value="">
         <div class="form-control-feedback invalid-feedback" id="id_error_qpy_form_my_rep_2_item">
             
         </div>
     </div>
-</div></div><div class="qpy-repetition-controls"><button name="qpy_repetition[qpy_form_my_rep_][remove][2]" type="submit" class="btn btn-secondary qpy-repetition-remove" value="remove"><i class="icon fa fa-trash fa-fw " title="Remove" role="img" aria-label="Remove"></i> Remove</button></div></div><div id="fitem_id_qpy_repetition_qpy_form_my_rep__add_more" class="form-group row  fitem femptylabel   ">
+</div></div><div class="qpy-repetition-controls"><button name="qpy_repetition[qpy_form_my_rep_][remove][2]" type="submit" class="btn btn-secondary qpy-repetition-remove" value="remove"><i class="icon fa fa-trash fa-fw " title="Remove" role="img" aria-label="Remove"></i> Remove</button></div></div><div id="fitem_id_qpy_repetition_qpy_form_my_rep__add_more" class="mb-3 row  fitem femptylabel   ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
         <div class="form-label-addon d-flex align-items-center align-self-start">
             
         </div>
     </div>
-    <div class="col-md-9 form-inline align-items-start felement" data-fieldtype="submit">
+    <div class="col-md-9 d-flex flex-wrap align-items-start felement" data-fieldtype="submit">
             <input type="submit" class="btn
                         
                         btn-secondary

--- a/tests/form/elements/html/select.html
+++ b/tests/form/elements/html/select.html
@@ -4,7 +4,7 @@
 <input name="_qf__qtype_questionpy_form_elements_test_moodleform" type="hidden" value="1">
 </div>
 
-<div id="fitem_id_qpy_form_my_select" class="form-group row  fitem    ">
+<div id="fitem_id_qpy_form_my_select" class="mb-3 row  fitem    ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
                 <label id="id_qpy_form_my_select_label" class="d-inline word-break " for="id_qpy_form_my_select">
@@ -18,7 +18,7 @@
             
         </div>
     </div>
-    <div class="col-md-9 form-inline align-items-start felement" data-fieldtype="select">
+    <div class="col-md-9 d-flex flex-wrap align-items-start felement" data-fieldtype="select">
             <input type="hidden" name="qpy_form[my_select]" value="_qf__force_multiselect_submission">
         <select class="
                        form-control

--- a/tests/form/elements/html/static_text.html
+++ b/tests/form/elements/html/static_text.html
@@ -4,7 +4,7 @@
 <input name="_qf__qtype_questionpy_form_elements_test_moodleform" type="hidden" value="1">
 </div>
 
-<div id="fitem_id_qpy_form_my_text" class="form-group row  fitem    ">
+<div id="fitem_id_qpy_form_my_text" class="mb-3 row  fitem    ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
                 <span class="d-inline-block ">
@@ -15,7 +15,7 @@
             
         </div>
     </div>
-    <div class="col-md-9 form-inline align-items-start felement" data-fieldtype="static">
+    <div class="col-md-9 d-flex flex-wrap align-items-start felement" data-fieldtype="static">
         <div class="form-control-static " data-name="qpy_form[my_text]">
         Lorem ipsum dolor sit amet.
         </div>

--- a/tests/form/elements/html/textarea.html
+++ b/tests/form/elements/html/textarea.html
@@ -4,7 +4,7 @@
 <input name="_qf__qtype_questionpy_form_elements_test_moodleform" type="hidden" value="1">
 </div>
 
-<div id="fitem_id_qpy_form_my_field" class="form-group row  fitem    ">
+<div id="fitem_id_qpy_form_my_field" class="mb-3 row  fitem    ">
     <div class="col-md-3 col-form-label d-flex pb-0 pr-md-0">
         
                 <label id="id_qpy_form_my_field_label" class="d-inline word-break " for="id_qpy_form_my_field">
@@ -18,7 +18,7 @@
             
         </div>
     </div>
-    <div class="col-md-9 form-inline align-items-start felement" data-fieldtype="textarea">
+    <div class="col-md-9 d-flex flex-wrap align-items-start felement" data-fieldtype="textarea">
         <textarea name="qpy_form[my_field]" id="id_qpy_form_my_field" class="form-control " aria-required="true" placeholder="placeholder">default</textarea>
         <div class="form-control-feedback invalid-feedback" id="id_error_qpy_form_my_field">
             

--- a/tests/http_response_container_test.php
+++ b/tests/http_response_container_test.php
@@ -26,7 +26,7 @@ use qtype_questionpy\api\http_response_container;
  * @copyright  2022 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class http_response_container_test extends \advanced_testcase {
+final class http_response_container_test extends \advanced_testcase {
     /**
      * Tests the function get_data with json.
      *
@@ -59,7 +59,7 @@ class http_response_container_test extends \advanced_testcase {
      * @return void
      * @throws moodle_exception
      */
-    public function test_get_data_not_json() {
+    public function test_get_data_not_json(): void {
         $code = 200;
         $data = 'This is not a json.';
 

--- a/tests/last_used_service_test.php
+++ b/tests/last_used_service_test.php
@@ -25,14 +25,14 @@ use moodle_exception;
  * @copyright  2024 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class last_used_service_test extends \advanced_testcase {
+final class last_used_service_test extends \advanced_testcase {
     /**
      * Tests {@see last_used_service::add()} create correct timestamp.
      *
      * @throws moodle_exception
      * @covers \qtype_questionpy\last_used_service::add
      */
-    public function test_add_creates_entry() {
+    public function test_add_creates_entry(): void {
         global $DB;
         $this->resetAfterTest();
 
@@ -53,7 +53,7 @@ class last_used_service_test extends \advanced_testcase {
      * @throws moodle_exception
      * @covers \qtype_questionpy\last_used_service::add
      */
-    public function test_add_updates_timestamp_if_package_was_already_used() {
+    public function test_add_updates_timestamp_if_package_was_already_used(): void {
         global $DB;
         $this->resetAfterTest();
 
@@ -81,7 +81,7 @@ class last_used_service_test extends \advanced_testcase {
      * @throws moodle_exception
      * @covers \qtype_questionpy\last_used_service::add
      */
-    public function test_add_inserts_entries_if_packages_differ() {
+    public function test_add_inserts_entries_if_packages_differ(): void {
         global $DB;
         $this->resetAfterTest();
 
@@ -107,7 +107,7 @@ class last_used_service_test extends \advanced_testcase {
      * @throws moodle_exception
      * @covers \qtype_questionpy\last_used_service::add
      */
-    public function test_add_inserts_entries_if_contexts_differ() {
+    public function test_add_inserts_entries_if_contexts_differ(): void {
         global $DB;
         $this->resetAfterTest();
 
@@ -133,7 +133,7 @@ class last_used_service_test extends \advanced_testcase {
      * @throws moodle_exception
      * @covers \qtype_questionpy\last_used_service::add
      */
-    public function test_add_inserts_entries_if_packages_and_contexts_differ() {
+    public function test_add_inserts_entries_if_packages_and_contexts_differ(): void {
         global $DB;
         $this->resetAfterTest();
 
@@ -175,7 +175,7 @@ class last_used_service_test extends \advanced_testcase {
      * @dataProvider context_count_provider
      * @covers \qtype_questionpy\last_used_service::remove_by_package
      */
-    public function test_remove_by_package_removes_the_entries(int $contexts) {
+    public function test_remove_by_package_removes_the_entries(int $contexts): void {
         global $DB;
         $this->resetAfterTest();
 
@@ -197,7 +197,7 @@ class last_used_service_test extends \advanced_testcase {
      * @throws moodle_exception
      * @covers \qtype_questionpy\last_used_service::remove_by_package
      */
-    public function test_remove_by_package_only_removes_the_given_package() {
+    public function test_remove_by_package_only_removes_the_given_package(): void {
         global $DB;
         $this->resetAfterTest();
 

--- a/tests/localizer_test.php
+++ b/tests/localizer_test.php
@@ -23,7 +23,7 @@ namespace qtype_questionpy;
  * @copyright  2022 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class localizer_test extends \advanced_testcase {
+final class localizer_test extends \advanced_testcase {
     /**
      * Test the default of the function get_preferred_language.
      *

--- a/tests/package/package_base_test.php
+++ b/tests/package/package_base_test.php
@@ -23,7 +23,7 @@ namespace qtype_questionpy\package;
  * @copyright  2023 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class package_base_test extends \advanced_testcase {
+final class package_base_test extends \advanced_testcase {
     /**
      * Tests the method get_localized_name.
      *

--- a/tests/package/package_raw_test.php
+++ b/tests/package/package_raw_test.php
@@ -31,7 +31,7 @@ require_once(dirname(__DIR__) . '/data_provider.php');
  * @copyright  2023 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class package_raw_test extends \advanced_testcase {
+final class package_raw_test extends \advanced_testcase {
     /**
      * Provides valid package data.
      *
@@ -138,7 +138,7 @@ class package_raw_test extends \advanced_testcase {
      * @return void
      * @throws moodle_exception
      */
-    public function test_faulty_from_array() {
+    public function test_faulty_from_array(): void {
         $this->expectException(moodle_exception::class);
         $faulty = ['faulty' => 'hash'];
         array_converter::from_array(package_raw::class, $faulty);
@@ -154,7 +154,7 @@ class package_raw_test extends \advanced_testcase {
      * @return void
      * @throws moodle_exception
      */
-    public function test_store_package($packagedata) {
+    public function test_store_package($packagedata): void {
         global $DB;
         $this->resetAfterTest();
 
@@ -219,7 +219,7 @@ class package_raw_test extends \advanced_testcase {
      * @return void
      * @throws moodle_exception
      */
-    public function test_store_package_twice() {
+    public function test_store_package_twice(): void {
         global $DB;
         $this->resetAfterTest();
 
@@ -241,7 +241,7 @@ class package_raw_test extends \advanced_testcase {
      * @return void
      * @throws moodle_exception
      */
-    public function test_store_already_existing_package_with_different_hash_throws() {
+    public function test_store_already_existing_package_with_different_hash_throws(): void {
         $this->resetAfterTest();
         $this->expectException(moodle_exception::class);
         $this->expectExceptionMessage('A package with the same version but different hash already exists.');
@@ -261,7 +261,7 @@ class package_raw_test extends \advanced_testcase {
      * @return void
      * @throws moodle_exception
      */
-    public function test_store_different_versions_of_a_package() {
+    public function test_store_different_versions_of_a_package(): void {
         global $DB;
         $this->resetAfterTest();
 

--- a/tests/package/package_test.php
+++ b/tests/package/package_test.php
@@ -30,7 +30,7 @@ require_once(dirname(__DIR__) . '/data_provider.php');
  * @copyright  2022 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class package_test extends \advanced_testcase {
+final class package_test extends \advanced_testcase {
     /**
      * Tests the method get_by_version.
      *
@@ -38,7 +38,7 @@ class package_test extends \advanced_testcase {
      * @return void
      * @throws moodle_exception
      */
-    public function test_get_by_version() {
+    public function test_get_by_version(): void {
         $this->resetAfterTest();
 
         // Store a package.
@@ -79,7 +79,7 @@ class package_test extends \advanced_testcase {
      * @return void
      * @throws moodle_exception
      */
-    public function test_delete() {
+    public function test_delete(): void {
         $this->resetAfterTest();
 
         // Store a package.
@@ -99,7 +99,7 @@ class package_test extends \advanced_testcase {
      * @return void
      * @throws moodle_exception
      */
-    public function test_delete_with_multiple_versions() {
+    public function test_delete_with_multiple_versions(): void {
         $this->resetAfterTest();
 
         // Store two versions of the same package.
@@ -120,7 +120,7 @@ class package_test extends \advanced_testcase {
      * @return void
      * @throws moodle_exception
      */
-    public function test_delete_with_multiple_packages() {
+    public function test_delete_with_multiple_packages(): void {
         $this->resetAfterTest();
 
         // Store two packages.
@@ -144,7 +144,7 @@ class package_test extends \advanced_testcase {
      * @covers \qtype_questionpy\package::equals
      * @return void
      */
-    public function test_difference_from() {
+    public function test_difference_from(): void {
         $package1 = new package(0, 'shortname', 'namespace', [], 'type', 'author', 'url', ['en', 'de']);
         $package2 = new package(1, 'shortname', 'namespace', [], 'type', 'author', 'url', ['de', 'en']);
 

--- a/tests/package/package_version_test.php
+++ b/tests/package/package_version_test.php
@@ -31,14 +31,14 @@ require_once(dirname(__DIR__) . '/data_provider.php');
  * @copyright  2023 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class package_version_test extends \advanced_testcase {
+final class package_version_test extends \advanced_testcase {
     /**
      * Tests the get_by_id method.
      *
      * @covers \package_version::get_by_id
      * @throws moodle_exception
      */
-    public function test_get_by_id() {
+    public function test_get_by_id(): void {
         $this->resetAfterTest();
 
         // Store a package.
@@ -59,7 +59,7 @@ class package_version_test extends \advanced_testcase {
      * @depends test_get_by_id
      * @throws moodle_exception
      */
-    public function test_get_by_hash() {
+    public function test_get_by_hash(): void {
         $this->resetAfterTest();
 
         // Store a package.
@@ -80,7 +80,7 @@ class package_version_test extends \advanced_testcase {
      * @depends test_get_by_id
      * @throws moodle_exception
      */
-    public function test_delete() {
+    public function test_delete(): void {
         global $DB;
         $this->resetAfterTest();
 
@@ -105,7 +105,7 @@ class package_version_test extends \advanced_testcase {
      * @depends test_get_by_id
      * @throws moodle_exception
      */
-    public function test_delete_where_multiple_versions_exist() {
+    public function test_delete_where_multiple_versions_exist(): void {
         global $DB;
         $this->resetAfterTest();
 

--- a/tests/question_service_test.php
+++ b/tests/question_service_test.php
@@ -33,7 +33,7 @@ use stdClass;
  * @copyright  2022 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class question_service_test extends \advanced_testcase {
+final class question_service_test extends \advanced_testcase {
     /** @var api */
     private api $api;
 
@@ -61,7 +61,7 @@ class question_service_test extends \advanced_testcase {
      * @throws moodle_exception
      * @covers \qtype_questionpy\question_service::get_question
      */
-    public function test_get_question_should_load_package_and_state() {
+    public function test_get_question_should_load_package_and_state(): void {
         $this->resetAfterTest();
 
         $package = package_provider();
@@ -88,7 +88,7 @@ class question_service_test extends \advanced_testcase {
      * @throws moodle_exception
      * @covers \qtype_questionpy\question_service::get_question
      */
-    public function test_get_question_should_return_empty_object_when_no_record() {
+    public function test_get_question_should_return_empty_object_when_no_record(): void {
         $this->assertEquals(new stdClass(), $this->questionservice->get_question(42));
     }
 
@@ -100,7 +100,7 @@ class question_service_test extends \advanced_testcase {
      * @throws moodle_exception
      * @covers \qtype_questionpy\question_service::upsert_question
      */
-    public function test_upsert_question_should_update_existing_record_if_changed() {
+    public function test_upsert_question_should_update_existing_record_if_changed(): void {
         global $PAGE;
         $this->resetAfterTest();
 
@@ -142,7 +142,7 @@ class question_service_test extends \advanced_testcase {
      * @throws dml_exception
      * @covers \qtype_questionpy\question_service::upsert_question
      */
-    public function test_upsert_question_should_do_nothing_if_unchanged() {
+    public function test_upsert_question_should_do_nothing_if_unchanged(): void {
         global $PAGE;
         $this->resetAfterTest();
 
@@ -182,7 +182,7 @@ class question_service_test extends \advanced_testcase {
      * @throws dml_exception
      * @covers \qtype_questionpy\question_service::upsert_question
      */
-    public function test_upsert_question_should_insert_record() {
+    public function test_upsert_question_should_insert_record(): void {
         global $PAGE;
         $this->resetAfterTest();
 
@@ -218,7 +218,7 @@ class question_service_test extends \advanced_testcase {
      * @throws dml_exception
      * @covers \qtype_questionpy\question_service::upsert_question
      */
-    public function test_upsert_question_should_throw_when_package_does_not_exist() {
+    public function test_upsert_question_should_throw_when_package_does_not_exist(): void {
         $hash = hash("sha256", rand());
 
         $this->expectException(moodle_exception::class);
@@ -242,7 +242,7 @@ class question_service_test extends \advanced_testcase {
      * @throws dml_exception
      * @covers \qtype_questionpy\question_service::upsert_question
      */
-    public function test_upsert_question_should_add_package_to_last_used_table() {
+    public function test_upsert_question_should_add_package_to_last_used_table(): void {
         global $DB, $PAGE;
         $this->resetAfterTest();
 
@@ -285,7 +285,7 @@ class question_service_test extends \advanced_testcase {
      * @throws dml_exception
      * @covers \qtype_questionpy\question_service::upsert_question
      */
-    public function test_upsert_question_in_same_context_with_same_package_should_only_update_time_used_in_last_used_table() {
+    public function test_upsert_question_in_same_context_with_same_package_should_only_update_time_used_in_last_used_table(): void {
         global $DB, $PAGE;
         $this->resetAfterTest();
 
@@ -348,7 +348,7 @@ class question_service_test extends \advanced_testcase {
      * @throws moodle_exception
      * @covers \qtype_questionpy\question_service::upsert_question
      */
-    public function test_delete_question() {
+    public function test_delete_question(): void {
         $this->resetAfterTest();
 
         $package = package_provider();

--- a/tests/question_type_test.php
+++ b/tests/question_type_test.php
@@ -23,14 +23,14 @@ namespace qtype_questionpy;
  * @copyright  2022 Martin Gauk, TU Berlin, innoCampus - www.questionpy.org
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class question_type_test extends \advanced_testcase {
+final class question_type_test extends \advanced_testcase {
     /**
      * Dummy Test (replace when we have real methods testing the question type).
      *
      * @coversNothing
      * @return void
      */
-    public function test_dummy() {
+    public function test_dummy(): void {
         $this->assertTrue(true);
     }
 }

--- a/tests/question_ui_metadata_extractor_test.php
+++ b/tests/question_ui_metadata_extractor_test.php
@@ -24,14 +24,14 @@ namespace qtype_questionpy;
  * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class question_ui_metadata_extractor_test extends \advanced_testcase {
+final class question_ui_metadata_extractor_test extends \advanced_testcase {
     /**
      * Tests that metadata is correctly extracted from the UI's input elements.
      *
      * @covers \qtype_questionpy\question_ui_metadata_extractor
      * @covers \qtype_questionpy\question_metadata
      */
-    public function test_should_extract_correct_metadata() {
+    public function test_should_extract_correct_metadata(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/metadata.xhtml");
 
         $metadata = new question_ui_metadata_extractor($input);

--- a/tests/question_ui_renderer_test.php
+++ b/tests/question_ui_renderer_test.php
@@ -26,7 +26,7 @@ use coding_exception;
  * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class question_ui_renderer_test extends \advanced_testcase {
+final class question_ui_renderer_test extends \advanced_testcase {
     /**
      * Asserts that two html strings are equal.
      *
@@ -57,7 +57,7 @@ class question_ui_renderer_test extends \advanced_testcase {
      * @throws coding_exception
      * @covers \qtype_questionpy\question_ui_renderer
      */
-    public function test_should_hide_inline_feedback() {
+    public function test_should_hide_inline_feedback(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/feedbacks.xhtml");
 
         $qa = $this->createStub(\question_attempt::class);
@@ -82,7 +82,7 @@ class question_ui_renderer_test extends \advanced_testcase {
      * @throws coding_exception
      * @covers \qtype_questionpy\question_ui_renderer
      */
-    public function test_should_show_inline_feedback() {
+    public function test_should_show_inline_feedback(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/feedbacks.xhtml");
 
         $qa = $this->createStub(\question_attempt::class);
@@ -108,7 +108,7 @@ class question_ui_renderer_test extends \advanced_testcase {
      * @throws coding_exception
      * @covers \qtype_questionpy\question_ui_renderer
      */
-    public function test_should_mangle_names() {
+    public function test_should_mangle_names(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/ids_and_names.xhtml");
 
         $qa = $this->createStub(\question_attempt::class);
@@ -152,7 +152,7 @@ class question_ui_renderer_test extends \advanced_testcase {
      * @throws coding_exception
      * @covers \qtype_questionpy\question_ui_renderer
      */
-    public function test_should_shuffle_the_same_way_in_same_attempt() {
+    public function test_should_shuffle_the_same_way_in_same_attempt(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/shuffle.xhtml");
         $qa = $this->createStub(\question_attempt::class);
         $qa->method("get_database_id")
@@ -172,7 +172,7 @@ class question_ui_renderer_test extends \advanced_testcase {
      * @throws coding_exception
      * @covers \qtype_questionpy\question_ui_renderer
      */
-    public function test_should_resolve_placeholders() {
+    public function test_should_resolve_placeholders(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/placeholder.xhtml");
         $qa = $this->createStub(\question_attempt::class);
         $qa->method("get_database_id")
@@ -203,7 +203,7 @@ class question_ui_renderer_test extends \advanced_testcase {
      * @throws coding_exception
      * @covers \qtype_questionpy\question_ui_renderer
      */
-    public function test_should_remove_placeholders_when_no_corresponding_value() {
+    public function test_should_remove_placeholders_when_no_corresponding_value(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/placeholder.xhtml");
         $qa = $this->createStub(\question_attempt::class);
         $qa->method("get_database_id")
@@ -230,7 +230,7 @@ class question_ui_renderer_test extends \advanced_testcase {
      * @throws coding_exception
      * @covers \qtype_questionpy\question_ui_renderer
      */
-    public function test_should_soften_validations() {
+    public function test_should_soften_validations(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/validations.xhtml");
         $qa = $this->createStub(\question_attempt::class);
         $qa->method("get_database_id")
@@ -260,7 +260,7 @@ class question_ui_renderer_test extends \advanced_testcase {
      * @throws coding_exception
      * @covers \qtype_questionpy\question_ui_renderer
      */
-    public function test_should_defuse_buttons() {
+    public function test_should_defuse_buttons(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/buttons.xhtml");
         $qa = $this->createStub(\question_attempt::class);
         $qa->method("get_database_id")
@@ -288,7 +288,7 @@ class question_ui_renderer_test extends \advanced_testcase {
      * @throws coding_exception
      * @covers \qtype_questionpy\question_ui_renderer
      */
-    public function test_should_remove_element_with_if_role_attribute() {
+    public function test_should_remove_element_with_if_role_attribute(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/if-role.xhtml");
         $qa = $this->createStub(\question_attempt::class);
         $qa->method("get_database_id")
@@ -315,7 +315,7 @@ class question_ui_renderer_test extends \advanced_testcase {
      * @throws coding_exception
      * @covers \qtype_questionpy\question_ui_renderer
      */
-    public function test_should_not_remove_element_with_if_role_attribute() {
+    public function test_should_not_remove_element_with_if_role_attribute(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/if-role.xhtml");
         $qa = $this->createStub(\question_attempt::class);
         $qa->method("get_database_id")
@@ -349,7 +349,7 @@ class question_ui_renderer_test extends \advanced_testcase {
      * @throws coding_exception
      * @covers \qtype_questionpy\question_ui_renderer
      */
-    public function test_should_format_floats_in_en() {
+    public function test_should_format_floats_in_en(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/format-floats.xhtml");
         $qa = $this->createStub(\question_attempt::class);
         $qa->method("get_database_id")

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qtype_questionpy';
-$plugin->version = 2025041806;
-$plugin->requires = 2022041901;
+$plugin->version = 2024072900;
+$plugin->requires = 2024042200;
 $plugin->maturity = MATURITY_ALPHA;
 $plugin->release = '0.1';


### PR DESCRIPTION
Im moodle-extra phpcs-Standard gab es ein paar Änderungen. Insbesondere sollen Lang-Strings jetzt alphabetisch sortiert sein, was schon weird genug ist, dass ich dafür mal einen PR mache. 

Ich habe unsere phpcs-Config auch mal in eine `phpcs.xml` gegossen, damit phpcs lokal sie auch benutzt. (Wenn wie [hier](https://moodledev.io/general/development/tools/phpcs#installation) beschrieben installiert)