### PR TITLE
#119: Statische Dateien ausliefern

### DIFF
--- a/classes/api/api.php
+++ b/classes/api/api.php
@@ -32,6 +32,17 @@ use TypeError;
  */
 class api {
     /**
+     * Initialize instance.
+     *
+     * @param qpy_http_client $client
+     */
+    public function __construct(
+        /** @var qpy_http_client */
+        private readonly qpy_http_client $client
+    ) {
+    }
+
+    /**
      * Retrieves QuestionPy packages from the application server.
      *
      * @return package_versions_info[]
@@ -64,7 +75,7 @@ class api {
      * @return package_api
      */
     public function package(string $hash, ?stored_file $file = null): package_api {
-        return new package_api($hash, $file);
+        return new package_api($this->client, $hash, $file);
     }
 
     /**

--- a/classes/api/package_api.php
+++ b/classes/api/package_api.php
@@ -17,11 +17,8 @@
 namespace qtype_questionpy\api;
 
 use coding_exception;
-use core\http_client;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Exception\InvalidArgumentException;
-use GuzzleHttp\Utils;
 use moodle_exception;
 use Psr\Http\Message\ResponseInterface;
 use qtype_questionpy\array_converter\array_converter;
@@ -183,9 +180,8 @@ class package_api {
                 throw $e;
             }
 
-            try {
-                $json = Utils::jsonDecode($e->getResponse()->getBody(), assoc: true);
-            } catch (InvalidArgumentException) {
+            $json = json_decode($e->getResponse()->getBody(), associative: true);
+            if (JSON_ERROR_NONE !== json_last_error()) {
                 // Not valid JSON, so the problem probably isn't a missing package file.
                 throw $e;
             }

--- a/classes/api/qpy_http_client.php
+++ b/classes/api/qpy_http_client.php
@@ -1,0 +1,59 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\api;
+
+use core\http_client;
+use dml_exception;
+use GuzzleHttp\HandlerStack;
+
+/**
+ * Guzzle http client configured with Moodle's standards ({@see http_client}) and QPy-specific ones.
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2024 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class qpy_http_client extends http_client {
+    /**
+     * Initializes a new client.
+     *
+     * @param array $config Guzzle config options. Mock handlers and history middleware can be added here, see
+     *                      {@link https://docs.guzzlephp.org/en/stable/testing.html#mock-handler}.
+     * @throws dml_exception
+     */
+    public function __construct(array $config = []) {
+        $config["base_uri"] = rtrim(get_config('qtype_questionpy', 'server_url'), "/") . "/";
+        $config["timeout"] = get_config('qtype_questionpy', 'server_timeout');
+        parent::__construct($config);
+    }
+
+    /**
+     * Get the handler stack according to the settings/options from client.
+     *
+     * @param array $settings The settings or options from client.
+     * @return HandlerStack
+     */
+    protected function get_handlers(array $settings): HandlerStack {
+        $handlerstack = parent::get_handlers($settings);
+        /* This checks requests against Moodle's curlsecurityblockedhosts, which we don't want, since admins would need
+           to ensure their QPy server isn't in this list otherwise. There may be ways to granularly allow the
+           server_url, but this will do for now. */
+        $handlerstack->remove("moodle_check_initial_request");
+        return $handlerstack;
+    }
+}

--- a/classes/external/load_packages.php
+++ b/classes/external/load_packages.php
@@ -21,6 +21,7 @@ defined('MOODLE_INTERNAL') || die;
 global $CFG;
 require_once($CFG->libdir . "/externallib.php");
 
+use core\di;
 use external_api;
 use external_function_parameters;
 use external_single_structure;
@@ -62,7 +63,7 @@ class load_packages extends external_api {
         $transaction = $DB->start_delegated_transaction();
 
         // Load and store packages from the application server.
-        $api = new api();
+        $api = di::get(api::class);
         $packages = $api->get_packages();
         $incomingpackageids = [];
         foreach ($packages as $package) {

--- a/classes/package_file_service.php
+++ b/classes/package_file_service.php
@@ -44,11 +44,11 @@ class package_file_service {
         $fs = get_file_storage();
         $files = $fs->get_area_files(
             $usercontext->id,
-            'user',
-            'draft',
-            $draftid,
-            'itemid, filepath, filename',
-            false
+            component: 'user',
+            filearea: 'draft',
+            itemid: $draftid,
+            includedirs: false,
+            limitnum: 1
         );
         if (!$files) {
             throw new coding_exception("draft file with id '$draftid' does not exist");
@@ -57,25 +57,26 @@ class package_file_service {
     }
 
     /**
-     * Get a {@see stored_file} with the given ID.
+     * Assumes that the question with the given id uses a local package and returns its package file.
      *
      * @param int $qpyid the id of the `qtype_questionpy` record
-     * @param int $contextid
+     * @param int $contextid context id of the question, e.g. {@see \question_definition::$contextid}
      * @return stored_file
-     * @throws coding_exception if no such draft file exists
+     * @throws coding_exception if no package file can be found for the given question, such as if the question isn't
+     *                          local after all.
      */
-    public function get_file(int $qpyid, int $contextid): stored_file {
+    public function get_file_for_local_question(int $qpyid, int $contextid): stored_file {
         $fs = get_file_storage();
         $files = $fs->get_area_files(
             $contextid,
-            'qtype_questionpy',
-            'package',
-            $qpyid,
-            'itemid, filepath, filename',
-            false
+            component: 'qtype_questionpy',
+            filearea: 'package',
+            itemid: $qpyid,
+            includedirs: false,
+            limitnum: 1
         );
         if (!$files) {
-            throw new coding_exception("package file with qpy id '$qpyid' does not exist");
+            throw new coding_exception("Package file with qpy id '$qpyid' does not exist.");
         }
         return reset($files);
     }

--- a/classes/question_ui_renderer.php
+++ b/classes/question_ui_renderer.php
@@ -564,7 +564,7 @@ class question_ui_renderer {
 
         return preg_replace_callback(
             // The first two path segments are namespace and short name, and so more restrictive.
-            ";qpy://static(/(?:[a-z_][a-z0-9_]{1,127}){2}(?:/[\w\-@:%+.~=]+)+);",
+            ";qpy://static((?:/[a-z_][a-z0-9_]{0,126}){2}(?:/[\w\-@:%+.~=]+)+);",
             function (array $match) use ($question) {
                 $path = $match[1];
                 $url = \moodle_url::make_pluginfile_url(

--- a/classes/static_file_service.php
+++ b/classes/static_file_service.php
@@ -1,0 +1,83 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy;
+
+use coding_exception;
+use context_system;
+use dml_exception;
+use invalid_dataroot_permissions;
+use qtype_questionpy\api\api;
+
+/**
+ * Handles retrieval, access control and caching of static package files.
+ *
+ * May also handle non-static attempt and scoring files files in the future, we'll see.
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2024 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class static_file_service {
+    /** @var api */
+    private readonly api $api;
+
+    /** @var package_file_service */
+    private readonly package_file_service $packagefileservice;
+
+    /**
+     * Trivial constructor.
+     * @param api $api
+     * @param package_file_service $packagefileservice
+     */
+    public function __construct(api $api, package_file_service $packagefileservice) {
+        $this->api = $api;
+        $this->packagefileservice = $packagefileservice;
+    }
+
+    /**
+     * Gets and serves the given static file from the QPy server and dies afterwards.
+     *
+     * TODO: Cache the file.
+     *
+     * @param string $packagehash
+     * @param string $namespace
+     * @param string $shortname
+     * @param string $path
+     * @return array{ 0: string, 1: string }|null array of temporary file path and mime type or null of the file wasn't
+     *                                            found
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws invalid_dataroot_permissions
+     */
+    public function download_public_static_file(string $packagehash, string $namespace, string $shortname, string $path): ?array {
+        $path = ltrim($path, "/");
+        $packagefileiflocal = $this->packagefileservice->get_file_by_package_hash($packagehash, context_system::instance()->id);
+
+        $temppath = make_request_directory() . "/$packagehash/$namespace/$shortname/$path";
+        make_writable_directory(dirname($temppath));
+
+        $mimetype = $this->api->package($packagehash, $packagefileiflocal)
+            ->download_static_file($namespace, $shortname, "static", $path, $temppath);
+
+        if (is_null($mimetype)) {
+            return null;
+        }
+
+        return [$temppath, $mimetype];
+    }
+}

--- a/edit_questionpy_form.php
+++ b/edit_questionpy_form.php
@@ -22,6 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use core\di;
 use core_question\local\bank\question_edit_contexts;
 use qtype_questionpy\api\api;
 use qtype_questionpy\form\context\root_render_context;
@@ -54,8 +55,8 @@ class qtype_questionpy_edit_form extends question_edit_form {
      */
     public function __construct(string $submiturl, object $question, object $category, question_edit_contexts $contexts,
                                 bool $formeditable = true) {
-        $this->api = new api();
-        $this->packagefileservice = new package_file_service();
+        $this->api = di::get(api::class);
+        $this->packagefileservice = di::get(package_file_service::class);
 
         parent::__construct($submiturl, $question, $category, $contexts, $formeditable);
     }
@@ -169,7 +170,7 @@ class qtype_questionpy_edit_form extends question_edit_form {
             $file = $this->packagefileservice->get_draft_file($draftid);
         } else {
             $qpyid = $this->question->qpy_id;
-            $file = $this->packagefileservice->get_file($qpyid, $this->context->get_course_context()->id);
+            $file = $this->packagefileservice->get_file_for_local_question($qpyid, $this->context->get_course_context()->id);
             $mform->addElement('hidden', 'qpy_package_path_name_hash', $file->get_pathnamehash());
             $mform->setType('qpy_package_path_name_hash', PARAM_ALPHANUM);
         }

--- a/question.php
+++ b/question.php
@@ -42,7 +42,7 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
     /** @var api */
     private api $api;
     /** @var string */
-    private string $packagehash;
+    public string $packagehash;
     /** @var string */
     private string $questionstate;
     /** @var stored_file|null */
@@ -64,10 +64,11 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
      * @param string $packagehash
      * @param string $questionstate
      * @param stored_file|null $packagefile
+     * @param api $api
      */
-    public function __construct(string $packagehash, string $questionstate, ?stored_file $packagefile) {
+    public function __construct(string $packagehash, string $questionstate, ?stored_file $packagefile, api $api) {
         parent::__construct();
-        $this->api = new api();
+        $this->api = $api;
         $this->packagehash = $packagehash;
         $this->questionstate = $questionstate;
         $this->packagefile = $packagefile;

--- a/questiontype.php
+++ b/questiontype.php
@@ -22,6 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use core\di;
 use qtype_questionpy\api\api;
 use qtype_questionpy\package_file_service;
 use qtype_questionpy\question_service;
@@ -53,9 +54,9 @@ class qtype_questionpy extends question_type {
      */
     public function __construct() {
         parent::__construct();
-        $this->api = new api();
-        $this->packagefileservice = new package_file_service();
-        $this->questionservice = new question_service($this->api, $this->packagefileservice);
+        $this->api = di::get(api::class);
+        $this->packagefileservice = di::get(package_file_service::class);
+        $this->questionservice = di::get(question_service::class);
     }
 
     /**
@@ -180,8 +181,13 @@ class qtype_questionpy extends question_type {
     protected function make_question_instance($questiondata) {
         $packagefile = null;
         if ($questiondata->qpy_is_local) {
-            $packagefile = $this->packagefileservice->get_file($questiondata->qpy_id, $questiondata->contextid);
+            $packagefile = $this->packagefileservice->get_file_for_local_question($questiondata->qpy_id, $questiondata->contextid);
         }
-        return new qtype_questionpy_question($questiondata->qpy_package_hash, $questiondata->qpy_state, $packagefile);
+        return new qtype_questionpy_question(
+            $questiondata->qpy_package_hash,
+            $questiondata->qpy_state,
+            $packagefile,
+            $this->api
+        );
     }
 }

--- a/tests/question_service_test.php
+++ b/tests/question_service_test.php
@@ -16,6 +16,10 @@
 
 namespace qtype_questionpy;
 
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . "/data_provider.php");
+
 use coding_exception;
 use dml_exception;
 use moodle_exception;

--- a/tests/question_ui_renderer_test.php
+++ b/tests/question_ui_renderer_test.php
@@ -16,7 +16,16 @@
 
 namespace qtype_questionpy;
 
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . "/question/type/questionpy/question.php");
+
 use coding_exception;
+use PHPUnit\Framework\MockObject\Stub;
+use qtype_questionpy\api\api;
+use qtype_questionpy_question;
+use question_attempt;
 
 /**
  * Unit tests for {@see question_ui_renderer}.
@@ -60,9 +69,7 @@ final class question_ui_renderer_test extends \advanced_testcase {
     public function test_should_hide_inline_feedback(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/feedbacks.xhtml");
 
-        $qa = $this->createStub(\question_attempt::class);
-        $qa->method("get_database_id")
-            ->willReturn(mt_rand());
+        $qa = $this->create_question_attempt_stub();
         $opts = new \question_display_options();
         $opts->hide_all_feedback();
 
@@ -85,9 +92,7 @@ final class question_ui_renderer_test extends \advanced_testcase {
     public function test_should_show_inline_feedback(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/feedbacks.xhtml");
 
-        $qa = $this->createStub(\question_attempt::class);
-        $qa->method("get_database_id")
-            ->willReturn(mt_rand());
+        $qa = $this->create_question_attempt_stub();
         $opts = new \question_display_options();
 
         $ui = new question_ui_renderer($input, [], $opts, $qa);
@@ -111,13 +116,7 @@ final class question_ui_renderer_test extends \advanced_testcase {
     public function test_should_mangle_names(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/ids_and_names.xhtml");
 
-        $qa = $this->createStub(\question_attempt::class);
-        $qa->method("get_database_id")
-            ->willReturn(mt_rand());
-        $qa->method("get_qt_field_name")
-            ->willReturnCallback(function ($name) {
-                return "mangled:$name";
-            });
+        $qa = $this->create_question_attempt_stub();
 
         $ui = new question_ui_renderer($input, [], new \question_display_options(), $qa);
         $result = $ui->render();
@@ -154,9 +153,7 @@ final class question_ui_renderer_test extends \advanced_testcase {
      */
     public function test_should_shuffle_the_same_way_in_same_attempt(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/shuffle.xhtml");
-        $qa = $this->createStub(\question_attempt::class);
-        $qa->method("get_database_id")
-            ->willReturn(mt_rand());
+        $qa = $this->create_question_attempt_stub();
 
         $firstresult = (new question_ui_renderer($input, [], new \question_display_options(), $qa))->render();
         for ($i = 0; $i < 10; $i++) {
@@ -174,9 +171,7 @@ final class question_ui_renderer_test extends \advanced_testcase {
      */
     public function test_should_resolve_placeholders(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/placeholder.xhtml");
-        $qa = $this->createStub(\question_attempt::class);
-        $qa->method("get_database_id")
-            ->willReturn(mt_rand());
+        $qa = $this->create_question_attempt_stub();
 
         $ui = new question_ui_renderer($input, [
             "param" => "Value of param <b>one</b>.<script>'Oh no, danger!'</script>",
@@ -205,9 +200,7 @@ final class question_ui_renderer_test extends \advanced_testcase {
      */
     public function test_should_remove_placeholders_when_no_corresponding_value(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/placeholder.xhtml");
-        $qa = $this->createStub(\question_attempt::class);
-        $qa->method("get_database_id")
-            ->willReturn(mt_rand());
+        $qa = $this->create_question_attempt_stub();
 
         $ui = new question_ui_renderer($input, [], new \question_display_options(), $qa);
         $result = $ui->render();
@@ -232,9 +225,7 @@ final class question_ui_renderer_test extends \advanced_testcase {
      */
     public function test_should_soften_validations(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/validations.xhtml");
-        $qa = $this->createStub(\question_attempt::class);
-        $qa->method("get_database_id")
-            ->willReturn(mt_rand());
+        $qa = $this->create_question_attempt_stub();
 
         $ui = new question_ui_renderer($input, [], new \question_display_options(), $qa);
         $result = $ui->render();
@@ -262,9 +253,7 @@ final class question_ui_renderer_test extends \advanced_testcase {
      */
     public function test_should_defuse_buttons(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/buttons.xhtml");
-        $qa = $this->createStub(\question_attempt::class);
-        $qa->method("get_database_id")
-            ->willReturn(mt_rand());
+        $qa = $this->create_question_attempt_stub();
 
         $ui = new question_ui_renderer($input, [], new \question_display_options(), $qa);
         $result = $ui->render();
@@ -290,9 +279,7 @@ final class question_ui_renderer_test extends \advanced_testcase {
      */
     public function test_should_remove_element_with_if_role_attribute(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/if-role.xhtml");
-        $qa = $this->createStub(\question_attempt::class);
-        $qa->method("get_database_id")
-            ->willReturn(mt_rand());
+        $qa = $this->create_question_attempt_stub();
 
         $this->resetAfterTest();
         $this->setGuestUser();
@@ -317,9 +304,7 @@ final class question_ui_renderer_test extends \advanced_testcase {
      */
     public function test_should_not_remove_element_with_if_role_attribute(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/if-role.xhtml");
-        $qa = $this->createStub(\question_attempt::class);
-        $qa->method("get_database_id")
-            ->willReturn(mt_rand());
+        $qa = $this->create_question_attempt_stub();
 
         $this->resetAfterTest();
         $this->setAdminUser();
@@ -351,9 +336,7 @@ final class question_ui_renderer_test extends \advanced_testcase {
      */
     public function test_should_format_floats_in_en(): void {
         $input = file_get_contents(__DIR__ . "/question_uis/format-floats.xhtml");
-        $qa = $this->createStub(\question_attempt::class);
-        $qa->method("get_database_id")
-            ->willReturn(mt_rand());
+        $qa = $this->create_question_attempt_stub();
 
         $ui = new question_ui_renderer($input, [], new \question_display_options(), $qa);
         $result = $ui->render();
@@ -369,5 +352,51 @@ final class question_ui_renderer_test extends \advanced_testcase {
             Strip zeros: 1.1
         </div>
         EXPECTED, $result);
+    }
+
+    /**
+     * Tests the replacement of QPy-URIs.
+     *
+     * @return void
+     * @throws coding_exception
+     * @covers \qtype_questionpy\question_ui_renderer::replace_qpy_urls
+     */
+    public function test_should_replace_qpy_urls(): void {
+        $input = file_get_contents(__DIR__ . "/question_uis/qpy-urls.xhtml");
+        $qa = $this->create_question_attempt_stub("deadbeef");
+
+        $ui = new question_ui_renderer($input, [], new \question_display_options(), $qa);
+        $result = $ui->render();
+
+        // phpcs:disable moodle.Files.LineLength.MaxExceeded
+        $this->assert_html_string_equals_html_string(<<<EXPECTED
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            static link: <a href="https://www.example.com/moodle/pluginfile.php//qtype_questionpy/static/deadbeef/local/minimal_example/path1/path2/filename.txt">https://www.example.com/moodle/pluginfile.php//qtype_questionpy/static/deadbeef/local/minimal_example/path1/path2/filename.txt</a>
+            minimal path: <a href="https://www.example.com/moodle/pluginfile.php//qtype_questionpy/static/deadbeef/local/minimal_example/f">https://www.example.com/moodle/pluginfile.php//qtype_questionpy/static/deadbeef/local/minimal_example/f</a>
+        </div>
+        EXPECTED, $result);
+        // phpcs:enable moodle.Files.LineLength.MaxExceeded
+    }
+
+    /**
+     * Creates a stub question attempt which should fulfill the needs of most tests.
+     *
+     * @param string|null $packagehash explicit package hash. Random if unset.
+     * @return question_attempt&Stub
+     */
+    private function create_question_attempt_stub(?string $packagehash = null): question_attempt {
+        $packagehash ??= hash("sha256", random_string(64));
+        $question = new qtype_questionpy_question($packagehash, "{}", null, $this->createStub(api::class));
+
+        $qa = $this->createStub(question_attempt::class);
+        $qa->method("get_database_id")
+            ->willReturn(mt_rand());
+        $qa->method("get_question")
+            ->willReturn($question);
+        $qa->method("get_qt_field_name")
+            ->willReturnCallback(function ($name) {
+                return "mangled:$name";
+            });
+        return $qa;
     }
 }

--- a/tests/question_uis/qpy-urls.xhtml
+++ b/tests/question_uis/qpy-urls.xhtml
@@ -1,0 +1,21 @@
+<!--
+  - This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+  -
+  - Moodle is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU General Public License as published by
+  - the Free Software Foundation, either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - Moodle is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU General Public License for more details.
+  -
+  - You should have received a copy of the GNU General Public License
+  - along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<div xmlns="http://www.w3.org/1999/xhtml">
+    static link: <a href="qpy://static/local/minimal_example/path1/path2/filename.txt">qpy://static/local/minimal_example/path1/path2/filename.txt</a>
+    minimal path: <a href="qpy://static/local/minimal_example/f">qpy://static/local/minimal_example/f</a>
+</div>

--- a/tests/static_file_service_test.php
+++ b/tests/static_file_service_test.php
@@ -1,0 +1,160 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . "/question/engine/tests/helpers.php");
+require_once(__DIR__ . "/data_provider.php");
+
+use coding_exception;
+use core\di;
+use dml_exception;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use invalid_dataroot_permissions;
+use moodle_exception;
+use qtype_questionpy\api\api;
+use qtype_questionpy\api\package_api;
+use qtype_questionpy\api\qpy_http_client;
+
+/**
+ * Tests QuestionPy static file access.
+ *
+ * Ideally, we'd call {@see file_pluginfile} to test the entire path, but that isn't possible since Moodle expects
+ * our pluginfile function to die after serving and {@see send_file} isn't testable (It ends all levels of output
+ * buffering).
+ *
+ * @package    qtype_questionpy
+ * @author     Maximilian Haye
+ * @copyright  2024 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @covers \qtype_questionpy\static_file_service
+ * @covers \qtype_questionpy\api\package_api::download_static_file
+ */
+final class static_file_service_test extends \advanced_testcase {
+    /** @var MockHandler */
+    private MockHandler $mockhandler;
+
+    /** @var array */
+    private array $requesthistory;
+
+    /** @var static_file_service */
+    private static_file_service $staticfileservice;
+
+    /**
+     * Sets up mocks and the like before each test.
+     *
+     * @throws dml_exception
+     */
+    protected function setUp(): void {
+        $this->mockhandler = new MockHandler();
+        $this->requesthistory = [];
+        $handlerstack = HandlerStack::create($this->mockhandler);
+        $handlerstack->push(Middleware::history($this->requesthistory));
+        $api = new api(new qpy_http_client([
+            "handler" => $handlerstack,
+        ]));
+        di::set(api::class, $api);
+
+        $packagefileservice = $this->createStub(package_file_service::class);
+        $packagefileservice
+            ->method("get_file_by_package_hash")
+            ->willReturn(null);
+
+        $this->staticfileservice = new static_file_service($api, $packagefileservice);
+    }
+
+    /**
+     * Tests the happy-path of a static file download.
+     *
+     * @return void
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws invalid_dataroot_permissions
+     */
+    public function test_should_download_public_static_file(): void {
+        $hash = random_string(64);
+        $this->mockhandler->append(new Response(200, [
+            "Content-Type" => "text/markdown",
+        ], "Static file content"));
+
+        [$path, $mimetype] = $this->staticfileservice->download_public_static_file(
+            $hash,
+            "local",
+            "example",
+            "/path/to/file.txt"
+        );
+
+        $this->assertStringEqualsFile($path, "Static file content");
+        $this->assertEquals("text/markdown", $mimetype);
+
+        $this->assertCount(1, $this->requesthistory);
+        /** @var Request $req */
+        $req = $this->requesthistory[0]["request"];
+        $this->assertEquals("POST", $req->getMethod());
+        $this->assertStringEndsWith("/packages/$hash/file/local/example/static/path/to/file.txt", $req->getUri());
+        $this->assertEquals(0, $req->getBody()->getSize());
+    }
+
+    /**
+     * Tests that we fall back to `octet-stream` and emit a warning when the response includes no Content-Type.
+     *
+     * @return void
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws invalid_dataroot_permissions
+     */
+    public function test_should_fall_back_and_warn_when_no_content_type(): void {
+        $this->mockhandler->append(new Response(200, [], "Static file content"));
+
+        [, $mimetype] = $this->staticfileservice->download_public_static_file(
+            random_string(64),
+            "local",
+            "example",
+            "/path/to/file.txt"
+        );
+
+        $this->assertEquals("application/octet-stream", $mimetype);
+        $this->assertDebuggingCalled("Server did not send Content-Type header, falling back to application/octet-stream");
+    }
+
+    /**
+     * Tests that null is returned when the server responds with 404, indicating that the static file doesn't exist.
+     *
+     * @return void
+     * @throws dml_exception
+     * @throws moodle_exception
+     */
+    public function test_should_return_null_when_file_doesnt_exist(): void {
+        $this->mockhandler->append(new Response(404, []));
+
+        $result = $this->staticfileservice->download_public_static_file(
+            random_string(64),
+            "local",
+            "example",
+            "/path/to/file.txt"
+        );
+
+        $this->assertNull($result);
+    }
+}


### PR DESCRIPTION
Ich hatte mir ursprünglich in den Kopf gesetzt, den ganzen Pfad von `file_pluginfile` bis inkl. `send_file` zu testen. Nach viel Zeitverschwendung bin ich aber zu dem Schluss gekommen, dass das nicht geht. U.a. geht Moodle davon aus, dass `qtype_questionpy_pluginfile` bei Erfolg immer `die`d, das lässt  sich auch für Tests nicht unterbinden. Und `send_file` macht alle Level von Output Buffering aus.

Zwei neue Dinge, die hier hinzukommen, sind die Nutzung des HTTP-Clients Guzzle und Moodle's Wrapper dafür, und Dependency Injection via <https://moodledev.io/docs/4.4/apis/core/di>. Den Rest des API-Codes sollten wir demnächst :tm: dann auch auf Guzzle umbiegen.

~~Aktuell scheitern die Actions beim Versuch, moodle-plugin-ci zu installieren. Das schaue ich mir morgen mal an, passiert aber auch auf dev.~~