### PR TITLE
fix(ci): remove workaround

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -61,8 +61,8 @@ jobs:
           echo $(cd ci/bin; pwd) >> $GITHUB_PATH
           echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
           sudo locale-gen en_AU.UTF-8
-          # Install nvm v0.39.7 (temp workaround for issue moodlehq/moodle-plugin-ci#309).
-          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+          # Define NVM_DIR pointing to nvm installation.
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
 
       - name: Install moodle-plugin-ci
         run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1


### PR DESCRIPTION
Closes #126

Mit 4.5.4 wurde das Problem behoben, [siehe](https://github.com/moodlehq/moodle-plugin-ci/issues/309#issuecomment-2306910175).
