### PR TITLE
feat: allow editing of packages removed from the database

### DIFF
--- a/classes/api/api.php
+++ b/classes/api/api.php
@@ -79,6 +79,20 @@ class api {
     }
 
     /**
+     * Get a {@see package_raw} from a package hash.
+     *
+     * @param string $hash
+     * @return package_raw
+     * @throws moodle_exception
+     */
+    public function get_package_info(string $hash): package_raw {
+        $connector = connector::default();
+        $response = $connector->get("/packages/$hash");
+        $response->assert_2xx();
+        return array_converter::from_array(package_raw::class, $response->get_data());
+    }
+
+    /**
      * Get a {@see package_raw} from a file.
      *
      * @param stored_file $file
@@ -99,6 +113,7 @@ class api {
         $response->assert_2xx();
         return array_converter::from_array(package_raw::class, $response->get_data());
     }
+
     /**
      * Get the status and information from the server.
      *

--- a/classes/last_used_service.php
+++ b/classes/last_used_service.php
@@ -52,12 +52,13 @@ class last_used_service {
     /**
      * Removes every entry with the given package id.
      *
-     * @param int $packageid
+     * @param int ...$packageids
      * @return void
      * @throws moodle_exception
      */
-    public static function remove_by_package(int $packageid): void {
+    public static function remove_by_package(int ...$packageids): void {
         global $DB;
-        $DB->delete_records('qtype_questionpy_lastused', ['packageid' => $packageid]);
+        [$insql, $inparams] = $DB->get_in_or_equal($packageids, SQL_PARAMS_NAMED, "packageids");
+        $DB->delete_records_select('qtype_questionpy_lastused', "packageid $insql", $inparams);
     }
 }

--- a/db/install.xml
+++ b/db/install.xml
@@ -25,16 +25,14 @@
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="questionid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Foreign key references question.id" />
-        <FIELD NAME="feedback" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Feedback shown for any response."/>
+        <FIELD NAME="packageidentifier" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" />
         <FIELD NAME="pkgversionhash" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="pkgversionid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="islocal" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="state" TYPE="text" NOTNULL="true" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id" />
         <KEY NAME="questionid" TYPE="foreign-unique" FIELDS="questionid" REFTABLE="question" REFFIELDS="id" />
-        <KEY NAME="pkgversionid" TYPE="foreign" FIELDS="pkgversionid" REFTABLE="qtype_questionpy_pkgversion" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
 

--- a/lang/en/qtype_questionpy.php
+++ b/lang/en/qtype_questionpy.php
@@ -60,8 +60,11 @@ $string['search_sort_label_aria'] = 'Sorting';
 $string['select_package'] = 'Select';
 $string['select_package_element_aria'] = 'Choose version.';
 $string['selection_custom_package_header'] = 'Custom Package';
-$string['selection_custom_package_text'] = 'This package was uploaded by a user and might not appear in the package search.';
+$string['selection_custom_package_text'] = 'This package version was uploaded by a user and might not appear in the package"
+    . " search.';
 $string['selection_no_icon'] = 'Could not load the icon.';
+$string['selection_package_no_longer_in_database_header'] = 'Discontinued';
+$string['selection_package_no_longer_in_database_text'] = 'This package version is no longer available through the package search.';
 $string['selection_required'] = 'Please select a package.';
 $string['selection_title'] = 'Select QuestionPy Package';
 $string['selection_title_selected'] = 'Selected Package';

--- a/templates/package/package_selection.mustache
+++ b/templates/package/package_selection.mustache
@@ -37,6 +37,7 @@
     * url - The url of the QuestionPy package,
     * isselected - Whether the current QuestionPy package is selected or not,
     * islocal - Whether the current QuestionPy package was uplaoded by a user or not,
+    * ismarkableasfavourite - Whether the current QuestionPy package can be marked as favourite or not,
     * isfavourite - Whether the current QuestionPy package is marked as favourite or not,
 
     Example context (json):
@@ -50,6 +51,7 @@
         "url": "https://example.com",
         "isselected": true,
         "islocal": false,
+        "ismarkableasfavourite": true,
         "isfavourite": false
     }
 }}
@@ -67,7 +69,7 @@
                         {{#pix}} i/moremenu {{/pix}}
                     </a>
                     <div class="dropdown-menu">
-                        {{^islocal}}
+                        {{#ismarkableasfavourite}}
                             <a class="dropdown-item" href="#" data-for="favourite-button" {{#isfavourite}} data-is-favourite {{/isfavourite}}>
                                 <span class="qpy-favourite-button-text">
                                     {{#pix}} i/star-rating {{/pix}}{{#str}} mark_as_favourite, qtype_questionpy {{/str}}
@@ -76,7 +78,7 @@
                                     {{#pix}} i/star-o {{/pix}}{{#str}} unmark_as_favourite, qtype_questionpy {{/str}}
                                 </span>
                             </a>
-                        {{/islocal}}
+                        {{/ismarkableasfavourite}}
                         {{#url}}
                             <a class="dropdown-item" href="{{url}}" target="_blank">{{#pix}} i/mnethost {{/pix}}{{#str}} open_website, qtype_questionpy {{/str}}</a>
                         {{/url}}
@@ -97,6 +99,14 @@
                         <span class="badge badge-info user-select-none mr-auto mb-2" data-toggle="tooltip" data-placement="top" data-title="{{#cleanstr}} selection_custom_package_text, qtype_questionpy {{/cleanstr}}">
                             &#9432; {{#str}} selection_custom_package_header, qtype_questionpy {{/str}}
                         </span>
+                    {{/islocal}}
+                    {{^islocal}}
+                        {{^ismarkableasfavourite}}
+                            {{! This package was previously in the database. }}
+                            <span class="badge badge-info user-select-none mr-auto mb-2" data-toggle="tooltip" data-placement="top" data-title="{{#cleanstr}} selection_package_no_longer_in_database_text, qtype_questionpy {{/cleanstr}}">
+                                &#9432; {{#str}} selection_package_no_longer_in_database_header, qtype_questionpy {{/str}}
+                            </span>
+                        {{/ismarkableasfavourite}}
                     {{/islocal}}
                     <button class="btn btn-danger qpy-version-selection-button">{{#str}} change_package, qtype_questionpy {{/str}}</button>
                 </div>


### PR DESCRIPTION
Closes #129.
![unavailable_package](https://github.com/user-attachments/assets/3905fedb-9ab6-41b4-a5ec-f4c98db4042f)

Zusätzlich:
Eine Frage mit einem QPy-Paket, welches zuvor in der Datenbank war und gelöscht wurde, kann immernoch editiert werden. Es kann allerdings nicht mehr favorisiert werden, die Option im Drop-Down-Menü erscheint nicht mehr, und es wird auch nicht im Recently-Used-Tab angezeigt.
Es wird darauf hingewiesen, dass dieses Paket nicht mehr über die Suche zu finden ist (siehe gif).
Gelöschte Pakete werden jetzt auch aus den Favoriten gelöscht.