### PR TITLE
feat: better error handling on worker error

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -1,5 +1,8 @@
 name: Moodle Plugin CI
 
+env:
+  QBEHAVIOUR_QUESTIONPY_COMMIT: df0da45416baa69a44bb700329a60b7a9df628bf
+
 on:
   push:
   pull_request:
@@ -63,6 +66,14 @@ jobs:
           sudo locale-gen en_AU.UTF-8
           # Define NVM_DIR pointing to nvm installation.
           echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Add qbehaviour_questionpy
+        run: |
+          moodle-plugin-ci add-plugin questionpy-org/moodle-qbehaviour_questionpy --storage extra-plugins
+          cd extra-plugins/moodle-qbehaviour_questionpy
+          # To move to a specific commit, we need to unshallow the repo (i.e. fetch all commits).
+          git fetch --unshallow
+          git switch --detach "$QBEHAVIOUR_QUESTIONPY_COMMIT"
 
       - name: Install moodle-plugin-ci
         run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1

--- a/classes/api/attempt_scored.php
+++ b/classes/api/attempt_scored.php
@@ -33,8 +33,8 @@ class attempt_scored extends attempt {
     /** @var string|null */
     public ?string $scoringstate;
 
-    /** @var string */
-    public string $scoringcode;
+    /** @var scoring_code */
+    public scoring_code $scoringcode;
 
     /** @var float|null */
     public ?float $score = null;
@@ -44,10 +44,10 @@ class attempt_scored extends attempt {
      *
      * @param int $variant
      * @param attempt_ui $ui
-     * @param string $scoringcode
+     * @param scoring_code $scoringcode
      * @param string|null $scoringstate
      */
-    public function __construct(int $variant, attempt_ui $ui, string $scoringcode, ?string $scoringstate = null) {
+    public function __construct(int $variant, attempt_ui $ui, scoring_code $scoringcode, ?string $scoringstate = null) {
         parent::__construct($variant, $ui);
 
         $this->scoringstate = $scoringstate;

--- a/classes/api/scoring_code.php
+++ b/classes/api/scoring_code.php
@@ -1,0 +1,33 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\api;
+
+// phpcs:ignore moodle.Commenting.InlineComment.DocBlock
+/**
+ * Possible scoring states.
+ *
+ * @package    qtype_questionpy
+ * @author     Jan Britz
+ * @copyright  2024 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+enum scoring_code: string {
+    case automatically_scored = "AUTOMATICALLY_SCORED";
+    case needs_manual_scoring = "NEEDS_MANUAL_SCORING";
+    case response_not_scorable = "RESPONSE_NOT_SCORABLE";
+    case invalid_response = "INVALID_RESPONSE";
+}

--- a/classes/array_converter/array_converter.php
+++ b/classes/array_converter/array_converter.php
@@ -120,6 +120,9 @@ class array_converter {
         if ($instance instanceof \BackedEnum) {
             return $instance->value;
         }
+        if ($instance instanceof \UnitEnum) {
+            throw new coding_exception("Only backed enums are supported.");
+        }
         if (is_scalar($instance) || $instance === null) {
             return $instance;
         }

--- a/classes/event/grading_response_failed.php
+++ b/classes/event/grading_response_failed.php
@@ -1,0 +1,68 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\event;
+
+use moodle_exception;
+use moodle_url;
+
+/**
+ * Grading attempt failed event.
+ *
+ * @package    qtype_questionpy
+ * @author     Jan Britz
+ * @copyright  2024 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class grading_response_failed extends \core\event\base {
+    /**
+     * Initialise event parameters.
+     */
+    protected function init() {
+        $this->data['crud'] = 'r';
+        $this->data['edulevel'] = self::LEVEL_TEACHING;
+    }
+
+    /**
+     * Returns localised event name.
+     *
+     * @return string
+     * @throws moodle_exception
+     */
+    public static function get_name() {
+        return get_string('event_grading_response_failed', 'qtype_questionpy');
+    }
+
+    /**
+     * Returns non-localised event description with id's for admin use only.
+     *
+     * @return string
+     */
+    public function get_description() {
+        return "The user with id '{$this->userid}' encountered an error when grading a response to the question with id " .
+            "'{$this->other['questionid']}': {$this->other['errormessage']}";
+    }
+
+    /**
+     * Validate our custom data.
+     */
+    public function validate_data() {
+        // The questionid can be null (e.g. in tests).
+        if (array_key_exists('questionid', $this->other) && !isset($this->other['errormessage'])) {
+            throw new \coding_exception('"questionid" and "errormessage" are required in "other".');
+        }
+    }
+}

--- a/classes/event/starting_attempt_failed.php
+++ b/classes/event/starting_attempt_failed.php
@@ -1,0 +1,69 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\event;
+
+use moodle_exception;
+use moodle_url;
+
+/**
+ * Starting attempt failed event.
+ *
+ * @package    qtype_questionpy
+ * @author     Jan Britz
+ * @copyright  2024 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class starting_attempt_failed extends \core\event\base {
+    /**
+     * Initialise event parameters.
+     */
+    protected function init() {
+        $this->data['crud'] = 'r';
+        $this->data['edulevel'] = self::LEVEL_PARTICIPATING;
+    }
+
+    /**
+     * Returns localised event name.
+     *
+     * @return string
+     * @throws moodle_exception
+     */
+    public static function get_name() {
+        return get_string('event_starting_attempt_failed', 'qtype_questionpy');
+    }
+
+    /**
+     * Returns non-localised event description with id's for admin use only.
+     *
+     * @return string
+     */
+    public function get_description() {
+        return "The user with id '$this->userid' encountered an error when starting a new attempt with usage id " .
+            "'{$this->other['attemptusageid']}' and slot '{$this->other['attemptslot']}' of the question with id " .
+            "'{$this->other['questionid']}': {$this->other['errormessage']}";
+    }
+
+    /**
+     * Validate our custom data.
+     */
+    public function validate_data() {
+        // The questionid can be null (e.g. in tests).
+        if (!array_key_exists('questionid', $this->other) && !isset($this->other['errormessage'])) {
+            throw new \coding_exception('"questionid" and "errormessage" are required in "other".');
+        }
+    }
+}

--- a/classes/event/viewing_attempt_failed.php
+++ b/classes/event/viewing_attempt_failed.php
@@ -1,0 +1,72 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy\event;
+
+use moodle_exception;
+use moodle_url;
+
+/**
+ * Viewing attempt failed event.
+ *
+ * @package    qtype_questionpy
+ * @author     Jan Britz
+ * @copyright  2024 TU Berlin, innoCampus {@link https://www.questionpy.org}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class viewing_attempt_failed extends \core\event\base {
+    /**
+     * Initialise event parameters.
+     */
+    protected function init() {
+        $this->data['crud'] = 'r';
+        $this->data['edulevel'] = self::LEVEL_PARTICIPATING;
+    }
+
+    /**
+     * Returns localised event name.
+     *
+     * @return string
+     * @throws moodle_exception
+     */
+    public static function get_name() {
+        return get_string('event_viewing_attempt_failed', 'qtype_questionpy');
+    }
+
+    /**
+     * Returns non-localised event description with id's for admin use only.
+     *
+     * @return string
+     */
+    public function get_description() {
+        return "The user with id '$this->userid' encountered an error when viewing the attempt with id " .
+            "'{$this->other["questionattemptid"]}' of the question with id '{$this->other["questionid"]}': " .
+            "{$this->other["errormessage"]}";
+    }
+
+    /**
+     * Validate our custom data.
+     */
+    public function validate_data() {
+        if (
+            // The questionid can be null (e.g. in tests).
+            !array_key_exists('questionid', $this->other) &&
+            !isset($this->other['questionattemptid'], $this->other['errormessage'])
+        ) {
+            throw new \coding_exception('"questionid", "questionattemptid", and "errormessage" are required in "other".');
+        }
+    }
+}

--- a/lang/en/qtype_questionpy.php
+++ b/lang/en/qtype_questionpy.php
@@ -26,6 +26,9 @@ $string['change_package'] = 'Change';
 $string['curl_exec_error'] = 'Error while fetching from server. Error number: {$a}';
 $string['curl_init_error'] = 'Could not initialize cURL. Error number: {$a}';
 $string['curl_set_opt_error'] = 'Failed to set cURL option. Error number: {$a}';
+$string['event_grading_response_failed'] = 'Grading response failed';
+$string['event_starting_attempt_failed'] = 'Starting attempt failed';
+$string['event_viewing_attempt_failed'] = 'Viewing attempt failed';
 $string['form_fallback_element_text'] = "The QuestionPy package is using a form element not supported by the Moodle"
     . " plugin. Please ensure you are using a compatible package or contact your administrators.";
 $string['formerror_noqpy_package'] = 'Selected file must be of type .qpy';
@@ -45,6 +48,7 @@ $string['pluginnamesummary'] = 'A comprehensive question type that allows you to
 $string['question_package_search'] = 'Select an existing package';
 $string['question_package_upload'] = 'Upload your own';
 $string['remove_packages_button'] = 'Remove Packages';
+$string['render_error_section'] = 'An error occurred';
 $string['same_version_different_hash_error'] = 'A package with the same version but different hash already exists.';
 $string['search_all_header'] = 'All ({$a})';
 $string['search_bar'] = 'Search...';

--- a/question.php
+++ b/question.php
@@ -159,8 +159,9 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
         $this->attemptstate = $attemptstate;
         $this->scoringstate = $this->get_behaviour()->get_qa()->get_last_qt_var(constants::QT_VAR_SCORING_STATE);
 
-        $lastresponse = array_filter(
-            $this->get_behaviour()->get_qa()->get_last_qt_data(null),
+        $lastqtdata = $this->get_behaviour()->get_qa()->get_last_qt_data(null);
+        $lastresponse = $lastqtdata === null ? null : array_filter(
+            $lastqtdata,
             fn($key) => !utils::str_starts_with($key, "_"),
             ARRAY_FILTER_USE_KEY
         );

--- a/question.php
+++ b/question.php
@@ -25,6 +25,7 @@
 use qtype_questionpy\api\api;
 use qtype_questionpy\api\attempt_ui;
 use qtype_questionpy\constants;
+use qtype_questionpy\api\scoring_code;
 use qtype_questionpy\question_ui_metadata_extractor;
 use qtype_questionpy\utils;
 
@@ -47,9 +48,9 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
 
     // Properties which do change between attempts (i.e. are modified by start_attempt and apply_attempt_state).
     /** @var string */
-    private string $attemptstate;
+    public string $attemptstate;
     /** @var string|null */
-    private ?string $scoringstate;
+    public ?string $scoringstate;
     /** @var attempt_ui */
     public attempt_ui $ui;
     /** @var question_ui_metadata_extractor $metadata */
@@ -99,15 +100,36 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
      *      being started. Can be used to store state.
      * @param int $variant which variant of this question to start. Will be between
      *      1 and {@see get_num_variants()} inclusive.
-     * @throws moodle_exception
+     * @throws Throwable
      */
     public function start_attempt(question_attempt_step $step, $variant): void {
-        $attempt = $this->api->package($this->packagehash, $this->packagefile)->start_attempt($this->questionstate, $variant);
+        global $PAGE;
 
-        $this->attemptstate = $attempt->attemptstate;
-        $step->set_qt_var(constants::QT_VAR_ATTEMPT_STATE, $attempt->attemptstate);
-        $this->scoringstate = null;
-        $this->update_ui($attempt->ui);
+        try {
+            $attempt = $this->api->package($this->packagehash, $this->packagefile)->start_attempt($this->questionstate, $variant);
+
+            $this->attemptstate = $attempt->attemptstate;
+            $step->set_qt_var(constants::QT_VAR_ATTEMPT_STATE, $attempt->attemptstate);
+            $this->scoringstate = null;
+            $this->update_ui($attempt->ui);
+        } catch (Throwable $t) {
+            // Trigger error event.
+            $qa = $this->get_behaviour()->get_qa();
+            $params = [
+                'context' => $PAGE->context,
+                'relateduserid' => $step->get_user_id(),
+                'other' => [
+                    'questionid' => $this->id,
+                    'attemptusageid' => $qa->get_usage_id(),
+                    'attemptslot' => $qa->get_slot(),
+                    'errormessage' => $t->getMessage(),
+                ],
+            ];
+            $event = \qtype_questionpy\event\starting_attempt_failed::create($params);
+            $event->trigger();
+            debugging($event->get_description());
+            throw $t;
+        }
     }
 
     /**
@@ -126,11 +148,12 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
      * @throws moodle_exception
      */
     public function apply_attempt_state(question_attempt_step $step) {
+        global $PAGE;
+
         $attemptstate = $step->get_qt_var(constants::QT_VAR_ATTEMPT_STATE);
         if (is_null($attemptstate)) {
-            // Start_attempt probably was never called, which it should have been.
-            $varname = constants::QT_VAR_ATTEMPT_STATE;
-            throw new coding_exception("apply_attempt_state was called, but attempt is missing qt var '$varname'");
+            // There was a request error at start_attempt.
+            return;
         }
 
         $this->attemptstate = $attemptstate;
@@ -144,14 +167,30 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
 
         /* TODO: This method is also called from question_attempt->regrade and
                  question_attempt->start_question_based_on, where we shouldn't need to get the UI. */
-        $attempt = $this->api->package($this->packagehash, $this->packagefile)
-            ->view_attempt(
-                $this->questionstate,
-                $this->attemptstate,
-                $this->scoringstate,
-                $lastresponse
-            );
-        $this->update_ui($attempt->ui);
+        try {
+            $attempt = $this->api->package($this->packagehash, $this->packagefile)
+                ->view_attempt(
+                    $this->questionstate,
+                    $this->attemptstate,
+                    $this->scoringstate,
+                    $lastresponse
+                );
+            $this->update_ui($attempt->ui);
+        } catch (Throwable $t) {
+            // Trigger error event.
+            $params = [
+                'context' => $PAGE->context,
+                'relateduserid' => $step->get_user_id(),
+                'other' => [
+                    'questionid' => $this->id,
+                    'questionattemptid' => $this->get_behaviour()->get_qa()->get_database_id(),
+                    'errormessage' => $t->getMessage(),
+                ],
+            ];
+            $event = \qtype_questionpy\event\viewing_attempt_failed::create($params);
+            $event->trigger();
+            debugging($event->get_description());
+        }
     }
 
     /**
@@ -175,11 +214,15 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
      * This information is used in calls to optional_param. The parameter name
      * has {@see question_attempt::get_field_prefix()} automatically prepended.
      *
-     * @return array variable name => PARAM_... constant, or, as a special case
+     * @return array|string variable name => PARAM_... constant, or, as a special case
      *      that should only be used in unavoidable, the constant question_attempt::USE_RAW_DATA
      *      meaning take all the raw submitted data belonging to this question.
      */
-    public function get_expected_data(): array {
+    public function get_expected_data(): array|string {
+        if (!isset($this->metadata)) {
+            // There was an error -> get all the submitted data.
+            return question_attempt::USE_RAW_DATA;
+        }
         return $this->metadata->extract()->expecteddata;
     }
 
@@ -192,6 +235,10 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
      * @return array|null parameter name => value.
      */
     public function get_correct_response(): ?array {
+        if (!isset($this->metadata)) {
+            // There was an error -> we cannot compute the correct response.
+            return null;
+        }
         return $this->metadata->extract()->correctresponse;
     }
 
@@ -205,6 +252,11 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
      * @return bool whether this response is a complete answer to this question.
      */
     public function is_complete_response(array $response): bool {
+        if (!isset($this->metadata)) {
+            // There was an error -> if no data was provided we want the question state to be set to INCOMPLETE.
+            return !empty($response);
+        }
+
         foreach ($this->metadata->extract()->requiredfields as $requiredfield) {
             if (!isset($response[$requiredfield]) || $response[$requiredfield] === "") {
                 return false;
@@ -261,35 +313,45 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
      * @throws moodle_exception
      */
     public function grade_response(array $response): array {
-        $attemptscored = $this->api->package($this->packagehash, $this->packagefile)->score_attempt(
-            $this->questionstate,
-            $this->attemptstate,
-            $this->scoringstate,
-            $response
-        );
-        $this->update_ui($attemptscored->ui);
+        global $PAGE;
+
+        try {
+            $attemptscored = $this->api->package($this->packagehash, $this->packagefile)->score_attempt(
+                $this->questionstate,
+                $this->attemptstate,
+                $this->scoringstate,
+                $response
+            );
+            $this->update_ui($attemptscored->ui);
+        } catch (Throwable $t) {
+            // Trigger error event.
+            $params = [
+                'context' => $PAGE->context,
+                // TODO: It would be nice to set a 'relateduserid'.
+                'other' => [
+                    'questionid' => $this->id,
+                    'errormessage' => $t->getMessage(),
+                ],
+            ];
+            $event = \qtype_questionpy\event\grading_response_failed::create($params);
+            $event->trigger();
+            debugging($event->get_description());
+
+            // As the server was not able to score the response, we mark this question with manual scoring.
+            return [0, question_state::$needsgrading];
+        }
 
         // Persist scoring state.
         $this->scoringstate = $attemptscored->scoringstate;
         $this->get_behaviour()->get_pending_step()
             ->set_qt_var(constants::QT_VAR_SCORING_STATE, $attemptscored->scoringstate);
 
-        switch ($attemptscored->scoringcode) {
-            case "AUTOMATICALLY_SCORED":
-                $newqstate = question_state::graded_state_for_fraction($attemptscored->score);
-                break;
-            case "NEEDS_MANUAL_SCORING":
-                $newqstate = question_state::$finished;
-                break;
-            case "RESPONSE_NOT_SCORABLE":
-                $newqstate = question_state::$gaveup;
-                break;
-            case "INVALID_RESPONSE":
-                $newqstate = question_state::$invalid;
-                break;
-            default:
-                throw new coding_exception("Unrecognized scoring code: $attemptscored->scoringcode");
-        }
+        $newqstate = match ($attemptscored->scoringcode) {
+            scoring_code::automatically_scored => question_state::graded_state_for_fraction($attemptscored->score),
+            scoring_code::needs_manual_scoring => question_state::$needsgrading,
+            scoring_code::response_not_scorable => question_state::$gaveup,
+            scoring_code::invalid_response => question_state::$invalid,
+        };
         return [$attemptscored->score, $newqstate];
     }
 

--- a/renderer.php
+++ b/renderer.php
@@ -51,11 +51,19 @@ class qtype_questionpy_renderer extends qtype_renderer {
      * @param question_attempt $qa the question attempt to display.
      * @param question_display_options $options controls what should and should not be displayed.
      * @return string HTML fragment.
-     * @throws coding_exception
+     * @throws moodle_exception
      */
     public function formulation_and_controls(question_attempt $qa, question_display_options $options): string {
         $question = $qa->get_question();
         assert($question instanceof qtype_questionpy_question);
+
+        if (!isset($question->ui)) {
+            return $this->output->render_from_template('qtype_questionpy/render_error', [
+                'message' => 'There was an error attempting to view the question.',
+                'info' => 'Please contact an administrator.',
+            ]);
+        }
+
         $renderer = new question_ui_renderer($question->ui->formulation, $question->ui->placeholders, $options, $qa);
         return $renderer->render();
     }
@@ -75,6 +83,11 @@ class qtype_questionpy_renderer extends qtype_renderer {
     public function feedback(question_attempt $qa, question_display_options $options): string {
         $question = $qa->get_question();
         assert($question instanceof qtype_questionpy_question);
+
+        if ($options->feedback && !isset($question->ui)) {
+            // We do not want to show another error message in the feedback section as there is already one in the formulations.
+            return '';
+        }
 
         $output = '';
         $hint = null;

--- a/templates/render_error.mustache
+++ b/templates/render_error.mustache
@@ -1,0 +1,36 @@
+<!--
+  ~ This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+  ~
+  ~ Moodle is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ Moodle is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with Moodle.  If not, see <http://www.gnu.org/licenses />.
+-->
+{{!
+    @template qtype_questionpy/render_error
+
+    Views the a render error.
+
+    Context variables required for this template:
+    * message - the error message
+    * info - more informations about the error
+
+    Example context (json):
+    {
+        "message":"This is an error message.",
+        "info": "Here are more informations about the error."
+    }
+}}
+<div>
+    <h4 class="text-danger">{{#str}} render_error_section, qtype_questionpy {{/str}}</h4>
+    <p>{{message}}</p>
+    <p>{{info}}</p>
+</div>

--- a/templates/settings/server_info.mustache
+++ b/templates/settings/server_info.mustache
@@ -19,6 +19,7 @@
 
     Displays information about the server and the server status.
 
+    TODO: faulty description.
     Context variables required for this template:
     * status - server information and status
     * description - localised field description

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -1,0 +1,224 @@
+<?php
+// This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_questionpy;
+
+use moodle_exception;
+use qtype_questionpy\api\api;
+use qtype_questionpy\api\package_api;
+use qtype_questionpy\event\grading_response_failed;
+use qtype_questionpy\event\starting_attempt_failed;
+use qtype_questionpy\event\viewing_attempt_failed;
+use qtype_questionpy_question;
+use question_attempt;
+use question_bank;
+use question_state;
+use Throwable;
+
+/**
+ * Unit tests for the questionpy question class.
+ *
+ * @package    qtype_questionpy
+ * @copyright  2024 Jan Britz, TU Berlin, innoCampus - www.questionpy.org
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class question_test extends \advanced_testcase {
+    /**
+     * @var api $api
+     */
+    private readonly api $api;
+
+    /**
+     * @var package_api $packageapi
+     */
+    private readonly package_api $packageapi;
+
+
+    /**
+     * This method is called before each test.
+     *
+     * @throws moodle_exception
+     */
+    protected function setUp(): void {
+        $this->resetAfterTest();
+
+        // Load questionpy.
+        question_bank::load_question_definition_classes('questionpy');
+
+        $this->api = $this->createMock(api::class);
+        $this->packageapi = $this->createMock(package_api::class);
+        $this->api->method('package')
+            ->willReturn($this->packageapi);
+    }
+
+    /**
+     * Create a QuestionPy question.
+     *
+     * @return qtype_questionpy_question
+     */
+    private function create_question(): qtype_questionpy_question {
+        return new qtype_questionpy_question(
+            hash('sha256', 'hash'),
+            'state',
+            packagefile: null,
+            api: $this->api
+        );
+    }
+
+    /**
+     * Tests that a failed start_attempt-call gets logged and neither the ui nor metadata gets set.
+     *
+     * @covers \qtype_questionpy_question::start_attempt
+     * @throws Throwable
+     */
+    public function test_start_attempt_request_failed(): void {
+        $exception = new \Exception('example error message');
+        $this->packageapi->method('start_attempt')
+            ->willThrowException($exception);
+
+        $question = $this->create_question();
+
+        $sink = $this->redirectEvents();
+
+        // Calling expectExpectation and assertDebuggingCalled seems buggy.
+        try {
+            $question->start_attempt(new \question_attempt_step(), 1);
+            $this->fail('An exception should have been thrown.');
+        } catch (\Exception $e) {
+            $this->assertEquals($exception, $e);
+        }
+
+        // Check if the event was created.
+        $events = $sink->get_events();
+        $event = reset($events);
+        $sink->close();
+
+        $this->assertCount(1, $events);
+        $this->assertInstanceOf(starting_attempt_failed::class, $event);
+        $this->assertStringContainsString($exception->getMessage(), $event->get_description());
+
+        // Check if debugging() was called.
+        $this->assertDebuggingCalled();
+
+        // Check if ui and metadata is not set.
+        $this->assertFalse(isset($question->ui));
+        $this->assertFalse(isset($question->metadata));
+    }
+
+    /**
+     * Tests that a failed apply_attempt_state-call gets logged and neither the ui nor metadata gets set.
+     *
+     * @covers \qtype_questionpy_question::apply_attempt_state
+     * @throws moodle_exception
+     */
+    public function test_apply_attempt_state_failed(): void {
+        $exception = new \Exception('example error message');
+        $this->packageapi->method('view_attempt')->willThrowException($exception);
+
+        $question = $this->create_question();
+
+        // Pretend that the question was started successfully.
+        $step = new \question_attempt_step();
+        $step->set_qt_var(constants::QT_VAR_ATTEMPT_STATE, 'state');
+
+        $sink = $this->redirectEvents();
+        $question->apply_attempt_state($step);
+
+        // Check if the event was created.
+        $events = $sink->get_events();
+        $event = reset($events);
+        $sink->close();
+
+        $this->assertCount(1, $events);
+        $this->assertInstanceOf(viewing_attempt_failed::class, $event);
+        $this->assertStringContainsString($exception->getMessage(), $event->get_description());
+
+        // Check if debugging() was called.
+        $this->assertDebuggingCalled();
+
+        // Check if ui and metadata is not set.
+        $this->assertFalse(isset($question->ui));
+        $this->assertFalse(isset($question->metadata));
+    }
+
+    /**
+     * Tests that a failed grade_response-call gets logged and the question is marked as needs manual grading.
+     *
+     * @covers \qtype_questionpy_question::grade_response
+     * @throws moodle_exception
+     */
+    public function test_grade_response_failed(): void {
+        $exception = new \Exception('example error message');
+        $this->packageapi->method('score_attempt')->willThrowException($exception);
+
+        $question = $this->create_question();
+        $question->attemptstate = 'state';
+        $question->scoringstate = 'state';
+
+        $sink = $this->redirectEvents();
+        [$fraction, $state] = $question->grade_response([]);
+
+        // Check if the event was created.
+        $events = $sink->get_events();
+        $event = reset($events);
+        $sink->close();
+
+        $this->assertCount(1, $events);
+        $this->assertInstanceOf(grading_response_failed::class, $event);
+        $this->assertStringContainsString($exception->getMessage(), $event->get_description());
+
+        // Check if debugging() was called.
+        $this->assertDebuggingCalled();
+
+        // Check the fraction and state.
+        $this->assertEquals(0, $fraction);
+        $this->assertEquals(question_state::$needsgrading, $state);
+
+        // Check if ui and metadata is not set.
+        $this->assertFalse(isset($question->ui));
+        $this->assertFalse(isset($question->metadata));
+    }
+
+    /**
+     * Tests that the method returns USE_RAW_DATA when no metadata is set.
+     *
+     * @covers \qtype_questionpy_question::get_expected_data
+     */
+    public function test_get_expected_data_should_return_use_raw_data_if_no_metadata(): void {
+        $question = $this->create_question();
+        $this->assertEquals(question_attempt::USE_RAW_DATA, $question->get_expected_data());
+    }
+
+    /**
+     * Tests that the method returns false if there is no metadata and no response.
+     *
+     * @covers \qtype_questionpy_question::is_complete_response
+     */
+    public function test_is_complete_response_should_return_false_if_no_metadata_and_no_response(): void {
+        $question = $this->create_question();
+        $this->assertFalse($question->is_complete_response([]));
+    }
+
+    /**
+     * Tests that the method returns true if there is no metadata but a response.
+     *
+     * @covers \qtype_questionpy_question::is_complete_response
+     */
+    public function test_is_complete_response_should_return_true_if_no_metadata_and_non_empty_response(): void {
+        $question = $this->create_question();
+        $this->assertTrue($question->is_complete_response(['test' => 'data']));
+    }
+}

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -16,7 +16,9 @@
 
 namespace qtype_questionpy;
 
+use coding_exception;
 use moodle_exception;
+use qbehaviour_questionpy;
 use qtype_questionpy\api\api;
 use qtype_questionpy\api\package_api;
 use qtype_questionpy\event\grading_response_failed;
@@ -25,6 +27,7 @@ use qtype_questionpy\event\viewing_attempt_failed;
 use qtype_questionpy_question;
 use question_attempt;
 use question_bank;
+use question_engine;
 use question_state;
 use Throwable;
 
@@ -68,14 +71,18 @@ final class question_test extends \advanced_testcase {
      * Create a QuestionPy question.
      *
      * @return qtype_questionpy_question
+     * @throws coding_exception
      */
     private function create_question(): qtype_questionpy_question {
-        return new qtype_questionpy_question(
+        question_engine::load_behaviour_class("questionpy");
+        $question = new qtype_questionpy_question(
             hash('sha256', 'hash'),
             'state',
             packagefile: null,
             api: $this->api
         );
+        $question->behaviour = $this->createStub(qbehaviour_questionpy::class);
+        return $question;
     }
 
     /**


### PR DESCRIPTION
Falls es ein Worker-Error beim Starten, Anzeigen oder Bewerten einer Frage Auftritt, wird das nutzerfreundlicher angezeigt:
![image](https://github.com/user-attachments/assets/85a6cedb-90de-422a-bd4c-48668dba72f1)

Und auch geloggt:
![image](https://github.com/user-attachments/assets/3007ebb7-ad21-45ac-806a-5422ab7d702e)

Sollten eine Frage (teilweise) beantwortet worden sein, werden beim Auftreten eines Fehlers alle Antworten gespeichert.
Falls ein Worker-Fehler beim Bewerten enstanden ist, wird die lehrende Person darauf aufmerksam gemacht, indem in der Scoring-Übersicht "Needs manual scoring" steht.