### PR TITLE
Behaviour in CI installieren und verwenden

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -1,5 +1,8 @@
 name: Moodle Plugin CI
 
+env:
+  QBEHAVIOUR_QUESTIONPY_COMMIT: df0da45416baa69a44bb700329a60b7a9df628bf
+
 on:
   push:
   pull_request:
@@ -63,6 +66,14 @@ jobs:
           sudo locale-gen en_AU.UTF-8
           # Define NVM_DIR pointing to nvm installation.
           echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Add qbehaviour_questionpy
+        run: |
+          moodle-plugin-ci add-plugin questionpy-org/moodle-qbehaviour_questionpy --storage extra-plugins
+          cd extra-plugins/moodle-qbehaviour_questionpy
+          # To move to a specific commit, we need to unshallow the repo (i.e. fetch all commits).
+          git fetch --unshallow
+          git switch --detach "$QBEHAVIOUR_QUESTIONPY_COMMIT"
 
       - name: Install moodle-plugin-ci
         run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1

--- a/question.php
+++ b/question.php
@@ -157,8 +157,9 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
         $this->attemptstate = $attemptstate;
         $this->scoringstate = $this->get_behaviour()->get_qa()->get_last_qt_var(constants::QT_VAR_SCORING_STATE);
 
-        $lastresponse = array_filter(
-            $this->get_behaviour()->get_qa()->get_last_qt_data(null),
+        $lastqtdata = $this->get_behaviour()->get_qa()->get_last_qt_data(null);
+        $lastresponse = $lastqtdata === null ? null : array_filter(
+            $lastqtdata,
             fn($key) => !utils::str_starts_with($key, "_"),
             ARRAY_FILTER_USE_KEY
         );

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -16,7 +16,9 @@
 
 namespace qtype_questionpy;
 
+use coding_exception;
 use moodle_exception;
+use qbehaviour_questionpy;
 use qtype_questionpy\api\api;
 use qtype_questionpy\api\package_api;
 use qtype_questionpy\event\grading_response_failed;
@@ -25,6 +27,7 @@ use qtype_questionpy\event\viewing_attempt_failed;
 use qtype_questionpy_question;
 use question_attempt;
 use question_bank;
+use question_engine;
 use question_state;
 use Throwable;
 
@@ -68,14 +71,18 @@ final class question_test extends \advanced_testcase {
      * Create a QuestionPy question.
      *
      * @return qtype_questionpy_question
+     * @throws coding_exception
      */
     private function create_question(): qtype_questionpy_question {
-        return new qtype_questionpy_question(
+        question_engine::load_behaviour_class("questionpy");
+        $question = new qtype_questionpy_question(
             hash('sha256', 'hash'),
             'state',
             packagefile: null,
             api: $this->api
         );
+        $question->behaviour = $this->createStub(qbehaviour_questionpy::class);
+        return $question;
     }
 
     /**


### PR DESCRIPTION
Ich habe es erstmal relativ banal gehalten, und checke nach `moodle-plugin-ci add-plugin` noch manuell einen bestimmten Hash aus. Der müsste dann bei Änderungen angepasst werden, vergleichbar mit den Commit-Hashes in unseren `pyproject.toml`s.

Früher oder später sollten wir uns dann überlegen, ob wir vielleicht Tags benutzen wollen.

Wenn ihr den PR annehmt, würde ich ihn analog für das Behaviour-Repo machen. (Wobei es da noch gar keine Tests gibt.)