### PR TITLE
#141: `type="hidden"` sollte auch wiederbefüllt werden

### DIFF
--- a/classes/question_ui_renderer.php
+++ b/classes/question_ui_renderer.php
@@ -261,7 +261,7 @@ class question_ui_renderer {
     /**
      * Transforms input(-like) elements.
      *
-     * - If {@see question_display_options} is set, the input is disabled.
+     * - If {@see question_display_options::$readonly} is set, the input is disabled.
      * - If a value was saved for the input in a previous step, the latest value is added to the HTML.
      *
      * Requires the unmangled name of the element, so must be called _before_ {@see mangle_ids_and_names}.
@@ -291,7 +291,14 @@ class question_ui_renderer {
             $lastvalue = $this->attempt->get_last_qt_var($name);
             if (!is_null($lastvalue)) {
                 if ($type === 'checkbox' || $type === 'radio') {
-                    if ($element->getAttribute('value') === $lastvalue) {
+                    // FIXME: Unchecked checkboxes send nothing, so we have no way of distinguishing an explicitly
+                    // unchecked checkbox from a checkbox which was not submitted (e.g. because it wasn't shown).
+                    // As it stands, a default-checked but explicitly unchecked checkbox will be checked again on next
+                    // view.
+                    $shouldbechecked = $element->hasAttribute('value')
+                        ? $element->getAttribute('value') === $lastvalue
+                        : $lastvalue === 'on';
+                    if ($shouldbechecked) {
                         $element->setAttribute('checked', 'checked');
                     } else {
                         $element->removeAttribute('checked');

--- a/classes/question_ui_renderer.php
+++ b/classes/question_ui_renderer.php
@@ -293,19 +293,24 @@ class question_ui_renderer {
                 if ($type === 'checkbox' || $type === 'radio') {
                     if ($element->getAttribute('value') === $lastvalue) {
                         $element->setAttribute('checked', 'checked');
+                    } else {
+                        $element->removeAttribute('checked');
                     }
                 } else if ($type == 'select') {
                     // Find the appropriate option and mark it as selected.
+                    // TODO: Support multiselects. Seems to be non-trivial, since QT vars only deal in strings, not
+                    // arrays.
                     /** @var DOMElement $option */
                     foreach ($element->getElementsByTagName('option') as $option) {
                         $optvalue = $option->hasAttribute('value') ? $option->getAttribute('value') : $option->textContent;
-                        if ($optvalue == $lastvalue) {
+                        if ($optvalue === $lastvalue) {
                             $option->setAttribute('selected', 'selected');
-                            break;
+                        } else {
+                            $option->removeAttribute('selected');
                         }
                     }
-                } else if ($type != "button" && $type != "submit") {
-                    $element->setAttribute("value", $lastvalue);
+                } else if ($type != 'button' && $type != 'submit') {
+                    $element->setAttribute('value', $lastvalue);
                 }
             }
         }

--- a/classes/question_ui_renderer.php
+++ b/classes/question_ui_renderer.php
@@ -304,8 +304,8 @@ class question_ui_renderer {
                             break;
                         }
                     }
-                } else if ($type != 'button' && $type != 'submit' && $type != 'hidden') {
-                    $element->setAttribute('value', $lastvalue);
+                } else if ($type != "button" && $type != "submit") {
+                    $element->setAttribute("value", $lastvalue);
                 }
             }
         }

--- a/tests/question_ui_renderer_test.php
+++ b/tests/question_ui_renderer_test.php
@@ -379,6 +379,53 @@ final class question_ui_renderer_test extends \advanced_testcase {
     }
 
     /**
+     * Tests {@see question_ui_renderer::set_input_values_and_readonly}.
+     *
+     * @return void
+     * @throws coding_exception
+     * @covers \qtype_questionpy\question_ui_renderer::set_input_values_and_readonly
+     */
+    public function test_should_correctly_fill_data(): void {
+        $input = file_get_contents(__DIR__ . '/question_uis/input-values.xhtml');
+        $qa = $this->create_question_attempt_stub('deadbeef');
+        $newvalues = [
+            'my_text' => 'new',
+            'my_checkbox' => 'value',
+            'my_radio' => 'value1',
+            'my_select' => 'value3',
+            'my_hidden' => 'new',
+            'my_button' => 'should be ignored',
+        ];
+        $qa->method('get_last_qt_var')
+            ->willReturnCallback(fn($name) => $newvalues[$name]);
+
+        $ui = new question_ui_renderer($input, [], new \question_display_options(), $qa);
+        $result = $ui->render();
+
+        $this->assert_html_string_equals_html_string(<<<EXPECTED
+        <div xmlns="http://www.w3.org/1999/xhtml" id="mangled:my_div">
+            <input class="form-control qpy-input" type="text" name="mangled:my_text" value="new"/>
+
+            <input class="qpy-input" type="checkbox" name="mangled:my_checkbox" value="value" checked="checked"/>
+
+            <input class="qpy-input" type="radio" name="mangled:my_radio" value="value1" checked="checked"/>
+            <input class="qpy-input" type="radio" name="mangled:my_radio" value="value2"/>
+
+            <select class="form-control qpy-input" name="mangled:my_select">
+                <option value="value1"/>
+                <option value="value2"/>
+                <option value="value3" selected="selected"/>
+            </select>
+
+            <input class="form-control qpy-input" type="hidden" name="mangled:my_hidden" value="new"/>
+
+            <input class="btn btn-primary qpy-input" name="mangled:my_button" type="button" value="value1"/>
+            <input class="btn btn-primary qpy-input" name="mangled:my_button" type="button" value="value2"/>
+        </div>
+        EXPECTED, $result);
+    }
+
+    /**
      * Creates a stub question attempt which should fulfill the needs of most tests.
      *
      * @param string|null $packagehash explicit package hash. Random if unset.

--- a/tests/question_ui_renderer_test.php
+++ b/tests/question_ui_renderer_test.php
@@ -390,7 +390,8 @@ final class question_ui_renderer_test extends \advanced_testcase {
         $qa = $this->create_question_attempt_stub('deadbeef');
         $newvalues = [
             'my_text' => 'new',
-            'my_checkbox' => 'value',
+            'my_checkbox_value' => 'value',
+            'my_checkbox_on' => 'on',
             'my_radio' => 'value1',
             'my_select' => 'value3',
             'my_hidden' => 'new',
@@ -406,7 +407,8 @@ final class question_ui_renderer_test extends \advanced_testcase {
         <div xmlns="http://www.w3.org/1999/xhtml" id="mangled:my_div">
             <input class="form-control qpy-input" type="text" name="mangled:my_text" value="new"/>
 
-            <input class="qpy-input" type="checkbox" name="mangled:my_checkbox" value="value" checked="checked"/>
+            <input class="qpy-input" type="checkbox" name="mangled:my_checkbox_value" value="value" checked="checked"/>
+            <input class="qpy-input" type="checkbox" name="mangled:my_checkbox_on" checked="checked"/>
 
             <input class="qpy-input" type="radio" name="mangled:my_radio" value="value1" checked="checked"/>
             <input class="qpy-input" type="radio" name="mangled:my_radio" value="value2"/>

--- a/tests/question_uis/input-values.xhtml
+++ b/tests/question_uis/input-values.xhtml
@@ -1,0 +1,36 @@
+<!--
+  - This file is part of the QuestionPy Moodle plugin - https://questionpy.org
+  -
+  - Moodle is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU General Public License as published by
+  - the Free Software Foundation, either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - Moodle is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU General Public License for more details.
+  -
+  - You should have received a copy of the GNU General Public License
+  - along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<div xmlns="http://www.w3.org/1999/xhtml" id="my_div">
+    <input type="text" name="my_text" value="original"/>
+
+    <input type="checkbox" name="my_checkbox" value="value"/>
+
+    <input type="radio" name="my_radio" value="value1"/>
+    <input type="radio" name="my_radio" value="value2" checked="checked"/>
+
+    <select name="my_select">
+        <option value="value1"/>
+        <option value="value2" selected="selected"/>
+        <option value="value3"/>
+    </select>
+
+    <input type="hidden" name="my_hidden" value="original"/>
+
+    <input name="my_button" type="button" value="value1"/>
+    <input name="my_button" type="button" value="value2"/>
+</div>

--- a/tests/question_uis/input-values.xhtml
+++ b/tests/question_uis/input-values.xhtml
@@ -18,7 +18,8 @@
 <div xmlns="http://www.w3.org/1999/xhtml" id="my_div">
     <input type="text" name="my_text" value="original"/>
 
-    <input type="checkbox" name="my_checkbox" value="value"/>
+    <input type="checkbox" name="my_checkbox_value" value="value"/>
+    <input type="checkbox" name="my_checkbox_on"/>
 
     <input type="radio" name="my_radio" value="value1"/>
     <input type="radio" name="my_radio" value="value2" checked="checked"/>


### PR DESCRIPTION
Der erste Commit beschäftigt sich mit dem Issue. Ich habe Buttons jetzt doch so gelassen, Begründung steht im Commit. Wäre aber trivial zu ändern, falls ich etwas übersehen habe.

Beim Testschreiben (dritter Commit) ist mir aufgefallen, dass Radios und Selects nicht wirklich funktionieren, das habe ich auch gefixt (zweiter Commit)

Und Multiselects funktionieren noch nicht. Da scheint mir ein Fix komplizierter, daher bin ich ihn noch nicht angegangen.