### PR TITLE
Verbesserungen am Question UI Renderer

### DIFF
--- a/classes/question_ui_renderer.php
+++ b/classes/question_ui_renderer.php
@@ -375,13 +375,14 @@ class question_ui_renderer {
             $rawvalue = $this->placeholders[$key];
             if (strtolower($cleanoption) === 'clean') {
                 // Allow HTML, but clean using Moodle's clean_text to prevent XSS.
-                $element = $this->xml->createDocumentFragment();
-                if (!$this->append_html_fragment($element, clean_text($rawvalue))) {
+                $element = $this->html_to_fragment($this->xml, clean_text($rawvalue));
+                if (!$element) {
                     debugging('clean_text produced invalid HTML');
+                    // Replace with empty fragment so we just remove the PI.
+                    $element = $this->xml->createDocumentFragment();
                 }
             } else if (strtolower($cleanoption) === 'noclean') {
-                $element = $this->xml->createDocumentFragment();
-                $this->append_html_fragment($element, $rawvalue, LIBXML_NOERROR);
+                $element = $this->html_to_fragment($this->xml, $rawvalue, LIBXML_NOERROR);
             } else {
                 if (strtolower($cleanoption) !== 'plain') {
                     debugging("Unrecognized placeholder cleaning option: '$cleanoption', using 'plain'");
@@ -395,15 +396,15 @@ class question_ui_renderer {
     }
 
     /**
-     * Parses and appends some HTML source to the given fragment.
+     * Parses some HTML source and returns a fragment.
      *
-     * @param DOMDocumentFragment $fragment
+     * @param DOMDocument $doc target document which the fragment should belong to
      * @param string $html
      * @param int $options
-     * @return bool
+     * @return DOMDocumentFragment|false fragment on success (or ignored errors), false on failure
      * @see DOMDocumentFragment::appendXML() the XML equivalent is provided by PHP, but not HTML :(
      */
-    private function append_html_fragment(DOMDocumentFragment $fragment, string $html, int $options = 0): bool {
+    private function html_to_fragment(DOMDocument $doc, string $html, int $options = 0): DOMDocumentFragment|false {
         $newdoc = new DOMDocument();
         // Libxml will add html and/or body elements and a DTD declaration without these options.
         $options |= LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD;
@@ -412,9 +413,10 @@ class question_ui_renderer {
             return false;
         }
 
+        $fragment = $doc->createDocumentFragment();
         /** @var DOMNode $childnode */
         foreach ($newdoc->documentElement->childNodes as $childnode) {
-            $imported = $fragment->ownerDocument->importNode($childnode, deep: true);
+            $imported = $doc->importNode($childnode, deep: true);
             if ($imported === false) {
                 debugging('Could not import HTML node from placeholder value');
                 return false;
@@ -422,7 +424,7 @@ class question_ui_renderer {
             $fragment->appendChild($imported);
         }
 
-        return true;
+        return $fragment;
     }
 
     /**

--- a/classes/question_ui_renderer.php
+++ b/classes/question_ui_renderer.php
@@ -19,6 +19,7 @@ namespace qtype_questionpy;
 use coding_exception;
 use DOMAttr;
 use DOMDocument;
+use DOMDocumentFragment;
 use DOMElement;
 use DOMNameSpaceNode;
 use DOMNode;
@@ -101,17 +102,28 @@ class question_ui_renderer {
 
         mt_srand($id);
         try {
-            $this->resolve_placeholders();
+            // Handle our custom elements and attributes.
             $this->hide_unwanted_feedback();
             $this->hide_if_role();
+            $this->shuffle_contents();
+            $this->format_floats();
+
+            // Remove all unhandled custom elements, attributes, comments, and non-default xmlns declarations.
+            $this->clean_up();
+
+            // Modify standard HTML.
             $this->set_input_values_and_readonly();
             $this->soften_validation();
             $this->defuse_buttons();
-            $this->shuffle_contents();
+
             $this->add_styles();
-            $this->format_floats();
+
+            // We don't want to support QPy elements (and attributes, etc.) in placeholder expansions, so we resolve
+            // them after replacing QPy elements.
+            $this->resolve_placeholders();
+            // I'm not sure whether we should support names and IDs in placeholder expansion, but if we do, we should
+            // probably mangle them as well.
             $this->mangle_ids_and_names();
-            $this->clean_up();
         } finally {
             // I'm not sure whether it is strictly necessary to reset the PRNG seed here, but it feels safer.
             // Resetting it to its original state would be ideal, but that doesn't seem to be possible.
@@ -343,7 +355,7 @@ class question_ui_renderer {
      * Replace placeholder PIs such as `<?p my_key plain?>` with the appropriate value from `$this->placeholders`.
      *
      * Since QPy transformations should not be applied to the content of the placeholders, this method should be called
-     * last.
+     * near the end (after {@see clean_up()}).
      *
      * @return void
      */
@@ -355,27 +367,62 @@ class question_ui_renderer {
             $cleanoption = $parts[1] ?? 'clean';
 
             if (!isset($this->placeholders[$key])) {
+                // No value for this placeholder, so we just remove the PI.
                 $pi->parentNode->removeChild($pi);
-            } else {
-                $rawvalue = $this->placeholders[$key];
-                if (strcasecmp($cleanoption, 'clean') == 0) {
-                    // Allow (X)HTML, but clean using Moodle's clean_text to prevent XSS.
-                    $element = $this->xpath->document->createDocumentFragment();
-                    $element->appendXML(clean_text($rawvalue));
-                } else if (strcasecmp($cleanoption, 'noclean') == 0) {
-                    $element = $this->xpath->document->createDocumentFragment();
-                    $element->appendXML($rawvalue);
-                } else {
-                    if (strcasecmp($cleanoption, 'plain') != 0) {
-                        debugging("Unrecognized placeholder cleaning option: '$cleanoption', using 'plain'");
-                    }
-                    // Treat the value as plain text and don't allow any kind of markup.
-                    // Since we're adding a text node, the DOM handles escaping for us.
-                    $element = new DOMText($rawvalue);
-                }
-                $pi->parentNode->replaceChild($element, $pi);
+                continue;
             }
+
+            $rawvalue = $this->placeholders[$key];
+            if (strtolower($cleanoption) === 'clean') {
+                // Allow HTML, but clean using Moodle's clean_text to prevent XSS.
+                $element = $this->xml->createDocumentFragment();
+                if (!$this->append_html_fragment($element, clean_text($rawvalue))) {
+                    debugging('clean_text produced invalid HTML');
+                }
+            } else if (strtolower($cleanoption) === 'noclean') {
+                $element = $this->xml->createDocumentFragment();
+                $this->append_html_fragment($element, $rawvalue, LIBXML_NOERROR);
+            } else {
+                if (strtolower($cleanoption) !== 'plain') {
+                    debugging("Unrecognized placeholder cleaning option: '$cleanoption', using 'plain'");
+                }
+                // Treat the value as plain text and don't allow any kind of markup.
+                // Since we're adding a text node, the DOM handles escaping for us.
+                $element = new DOMText($rawvalue);
+            }
+            $pi->parentNode->replaceChild($element, $pi);
         }
+    }
+
+    /**
+     * Parses and appends some HTML source to the given fragment.
+     *
+     * @param DOMDocumentFragment $fragment
+     * @param string $html
+     * @param int $options
+     * @return bool
+     * @see DOMDocumentFragment::appendXML() the XML equivalent is provided by PHP, but not HTML :(
+     */
+    private function append_html_fragment(DOMDocumentFragment $fragment, string $html, int $options = 0): bool {
+        $newdoc = new DOMDocument();
+        // Libxml will add html and/or body elements and a DTD declaration without these options.
+        $options |= LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD;
+        // Despite LIBXML_HTML_NOIMPLIED, libxml will wrap a <p>-tag around the html if it doesn't have a root element.
+        if (!$newdoc->loadHTML('<body>' . $html . '</body>', $options)) {
+            return false;
+        }
+
+        /** @var DOMNode $childnode */
+        foreach ($newdoc->documentElement->childNodes as $childnode) {
+            $imported = $fragment->ownerDocument->importNode($childnode, deep: true);
+            if ($imported === false) {
+                debugging('Could not import HTML node from placeholder value');
+                return false;
+            }
+            $fragment->appendChild($imported);
+        }
+
+        return true;
     }
 
     /**

--- a/tests/question_ui_renderer_test.php
+++ b/tests/question_ui_renderer_test.php
@@ -192,6 +192,39 @@ final class question_ui_renderer_test extends \advanced_testcase {
     }
 
     /**
+     * Tests that broken HTML in placeholder values is handled correctly depending on clean mode.
+     *
+     * @return void
+     * @throws coding_exception
+     * @covers \qtype_questionpy\question_ui_renderer::resolve_placeholders
+     */
+    public function test_should_correctly_handle_broken_html_in_placeholder_expansion(): void {
+        $input = file_get_contents(__DIR__ . '/question_uis/placeholder.xhtml');
+        $qa = $this->create_question_attempt_stub();
+
+        $ui = new question_ui_renderer($input, [
+            'param' => '<qpy:format-float>123</qpy:format-float><unknown-tag></unknown-tag><div>unclosed',
+            'description' => 'My simple description.',
+        ], new \question_display_options(), $qa);
+        $result = $ui->render();
+
+        // For noclean, the qpy namespace prefix is unknown when appending the XML. Since we want to support as much
+        // broken HTML/XML in user input as possible, the DOM just removes the prefix.
+
+        // phpcs:disable moodle.Files.LineLength.TooLong
+        $this->assert_html_string_equals_html_string(<<<EXPECTED
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            <div>My simple description.</div>
+            <span>By default cleaned parameter: 123<div>unclosed</div></span>
+            <span>Explicitly cleaned parameter: 123<div>unclosed</div></span>
+            <span>Noclean parameter: <format-float>123</format-float><unknown-tag></unknown-tag><div>unclosed</div></span>
+            <span>Plain parameter: &lt;qpy:format-float>123&lt;/qpy:format-float>&lt;unknown-tag>&lt;/unknown-tag>&lt;div>unclosed</span>
+        </div>
+        EXPECTED, $result);
+        // phpcs:enable moodle.Files.LineLength.TooLong
+    }
+
+    /**
      * Tests that placeholders are just removed when the corresponding value is missing.
      *
      * @return void


### PR DESCRIPTION
- `resolve_placeholders` hat schon immer den korrekten Satz im PHPdoc, das es zuletzt aufgerufen werden sollte, wurde aber als Erstes aufgerufen. Die Reihenfolge der Transformationen habe ich jetzt nochmal überdacht, und im Code kommentiert.
- Bisher haben wir die Werte von `<?p`latzhaltern als XML interpretiert. Das passte schon nicht so ganz, weil `clean_text` eigentlich für HTML gedacht ist. Außerdem ist HTML vermutlich sinnvoller, die meisten Leute (in diesem Fall ja insb. nicht-Entwickler:innen) kennen kein XHTML.
- Im Falle von kaputtem HTML nach `clean_text` wird jetzt eine `coding_exception` geworfen. (Ich vermute das sollte nicht passieren, zumindest halte ich es für gefährlich, womöglich invalides nicht-vertrauenswürdiges HTML auszugeben.)
- Bei `noclean` (wo dem Inhalt also vertraut wird) habe ich mich entschieden, Fehler zu ignorieren (`LIBXML_NOERROR`). Das hat den Vorteil, dass libxml dann so gut es geht valides HTML daraus macht (z.B. Tags selbst schließt).
- Und ein Test für die vorherigen beiden Punkte.