### PR TITLE
feat: view form validation errors

### DIFF
--- a/classes/question_service.php
+++ b/classes/question_service.php
@@ -144,7 +144,7 @@ class question_service {
             'questionid' => $question->id,
         ]);
 
-        // Repetition_elements may produce numeric arrays with gaps. We want them to become JSON arrays, so we reindex.
+        // Repetition elements may produce numeric arrays with gaps. We want them to become JSON arrays, so we reindex.
         // Form element names may not begin with a digit, so this won't accidentally change them.
         utils::reindex_integer_arrays($question->qpy_form);
 

--- a/edit_questionpy_form.php
+++ b/edit_questionpy_form.php
@@ -24,13 +24,17 @@
 
 use core\di;
 use core_question\local\bank\question_edit_contexts;
+use GuzzleHttp\Exception\GuzzleException;
 use qtype_questionpy\api\api;
+use qtype_questionpy\exception\options_form_validation_error;
+use qtype_questionpy\exception\request_error;
 use qtype_questionpy\form\context\root_render_context;
 use qtype_questionpy\localizer;
 use qtype_questionpy\package\package;
 use qtype_questionpy\package\package_base;
 use qtype_questionpy\package\package_version;
 use qtype_questionpy\package_file_service;
+use qtype_questionpy\utils;
 
 /**
  * QuestionPy question editing form definition.
@@ -298,34 +302,88 @@ class qtype_questionpy_edit_form extends question_edit_form {
     }
 
     /**
-     * Validates selected or uploaded package.
+     * Validates the options form of the package.
+     *
+     * @param array $data
+     * @param stored_file|null $package
+     * @param array $errors
+     * @return void
+     * @throws GuzzleException
+     * @throws request_error
+     * @throws moodle_exception
+     */
+    private function validate_options_form(array $data, ?stored_file $package, array &$errors): void {
+        try {
+            $packagehash = $data['qpy_package_hash'] ?? $data['qpy_package_file_hash'];
+
+            // Repetition elements may produce numeric arrays with gaps. We want them to become JSON arrays, so we reindex.
+            // Form element names may not begin with a digit, so this won't accidentally change them.
+            utils::reindex_integer_arrays($data['qpy_form']);
+
+            // TODO: create a dedicated endpoint?
+            $this->api->package($packagehash, $package)->create_question(null, (object) $data['qpy_form']);
+        } catch (options_form_validation_error $error) {
+            foreach ($error->errors as $field => $error) {
+                $element = 'qpy_form[' . str_replace('.', '][', $field) . ']';
+                if ($this->_form->elementExists($element)) {
+                    $errors[$element] = $error;
+                }
+            }
+        }
+    }
+
+    /**
+     * Validates the selected, freshly uploaded or previously uploaded package.
+     *
+     * If the package is a local one, it gets returned.
+     *
+     * @param array $data
+     * @param array $errors
+     * @return stored_file|null
+     * @throws coding_exception
+     */
+    private function validate_selected_package(array $data, array &$errors): stored_file|null {
+        global $USER;
+
+        $source = $data['qpy_package_source'] ?? null;
+        if ($source == 'search' && empty($data['qpy_package_hash'])) {
+            $errors['qpy_package_container'] = get_string('required');
+        } else if ($source == 'upload') {
+            $filestorage = get_file_storage();
+
+            if (!empty($data['qpy_package_path_name_hash'])) {
+                // The package was already uploaded.
+                $package = $filestorage->get_file_by_hash($data['qpy_package_path_name_hash']);
+            } else {
+                // A new package is uploaded.
+                $usercontext = context_user::instance($USER->id);
+                $package = $filestorage->get_area_files($usercontext->id, 'user', 'draft', $data['qpy_package_file']);
+                $package = reset($package);
+            }
+
+            if (!$package) {
+                $errors['qpy_package_file'] = get_string('required');
+            } else {
+                return $package;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Validates the form.
      *
      * @param array $data
      * @param array $files
      * @return array $errors
-     * @throws moodle_exception
+     * @throws moodle_exception|GuzzleException
      */
     public function validation($data, $files) {
-        global $USER;
         $errors = parent::validation($data, $files);
-
-        $source = $data['qpy_package_source'] ?? null;
-        if ($source == 'search') {
-            if (empty($data['qpy_package_hash'])) {
-                $errors['qpy_package_container'] = get_string('required');
-            }
-        } else if ($source == 'upload') {
-            $filestorage = get_file_storage();
-            if (isset($data['qpy_package_path_name_hash'])) {
-                if (!$filestorage->file_exists_by_hash($data['qpy_package_path_name_hash'])) {
-                    $errors['qpy_package_file'] = get_string('required');
-                }
-            } else {
-                $usercontext = context_user::instance($USER->id);
-                if (!$filestorage->get_area_files($usercontext->id, 'user', 'draft', $data['qpy_package_file'])) {
-                    $errors['qpy_package_file'] = get_string('required');
-                }
-            }
+        $package = $this->validate_selected_package($data, $errors);
+        if ($data['qpy_package_selected']) {
+            // The options form of a package is being submitted.
+            $this->validate_options_form($data, $package, $errors);
         }
 
         return $errors;

--- a/edit_questionpy_form.php
+++ b/edit_questionpy_form.php
@@ -313,22 +313,45 @@ class qtype_questionpy_edit_form extends question_edit_form {
      * @throws moodle_exception
      */
     private function validate_options_form(array $data, ?stored_file $package, array &$errors): void {
+        $errorswithnoelement = [];
+
         try {
             $packagehash = $data['qpy_package_hash'] ?? $data['qpy_package_file_hash'];
 
             // Repetition elements may produce numeric arrays with gaps. We want them to become JSON arrays, so we reindex.
             // Form element names may not begin with a digit, so this won't accidentally change them.
-            utils::reindex_integer_arrays($data['qpy_form']);
+            if (!empty($data['qpy_form'])) {
+                utils::reindex_integer_arrays($data['qpy_form']);
+            }
 
             // TODO: create a dedicated endpoint?
-            $this->api->package($packagehash, $package)->create_question(null, (object) $data['qpy_form']);
+            $this->api->package($packagehash, $package)->create_question(
+                $this->question->qpy_state ?? null,
+                (object) $data['qpy_form']
+            );
         } catch (options_form_validation_error $error) {
             foreach ($error->errors as $field => $error) {
                 $element = 'qpy_form[' . str_replace('.', '][', $field) . ']';
                 if ($this->_form->elementExists($element)) {
                     $errors[$element] = $error;
+                } else {
+                    $errorswithnoelement[$element] = $error;
                 }
             }
+        }
+
+        if (!empty($errorswithnoelement)) {
+            $listitems = [];
+            foreach ($errorswithnoelement as $element => $error) {
+                $listitems[] = get_string('options_form_validation_error_element', 'qtype_questionpy', [
+                    'name' => $element,
+                    'error' => $error,
+                ]);
+            }
+            $list = html_writer::alist($listitems);
+            $composederrorstring = get_string('options_form_validation_error_container', 'qtype_questionpy', $list);
+            // Use the 'Question name' input field to view the errors.
+            $errors['name'] = $composederrorstring;
         }
     }
 

--- a/lang/en/qtype_questionpy.php
+++ b/lang/en/qtype_questionpy.php
@@ -34,6 +34,9 @@ $string['mark_as_favourite'] = 'Favourite';
 $string['max_package_size_kb'] = 'Maximum file size of a QuestionPy package';
 $string['max_package_size_kb_description'] = 'Maximum file size in kB';
 $string['open_website'] = 'Open website';
+$string['options_form_validation_error_element'] = '{$a->name}: {$a->error}';
+$string['options_form_validation_error_title'] = 'The following errors occurred while validating the form and could not'
+    . ' be mapped to an input element: {$a}';
 $string['package_not_found'] = 'The requested package {$a->packagehash} does not exist.';
 $string['packages_subheading'] = 'Packages';
 $string['pluginname'] = 'QuestionPy';


### PR DESCRIPTION
Closes #152. Abhängig von #154.

![image](https://github.com/user-attachments/assets/058b5a9e-de4a-4a1c-b0d7-4f8480ef55d3)

Falls es Fehlermeldungen gibt, die keinem bestimmten Element zugeordnet werden können, werden sie unter dem 'Question name'-Element angezeigt.
 
![image](https://github.com/user-attachments/assets/7d86dad2-b195-4b7f-987f-1c1607e9fa5c)

Am saubersten wäre es, im Server einen `/validate-options-form`-Enpoint zu erstellen, welcher nur die Options Form validiert und bei einem Erfolg den Statuscode 200 zurückgibt. Wie seht ihr das?


PS:
Ich wollte die Fehlerbehandlung direkt beim Abspeichern der Frage bzw. beim Aufruf von `save_question_options` vollziehen, da dadurch nur ein Request zum Server gemacht werden muss. Das war in einer früheren Moodle Version auch möglich, jetzt aber nicht mehr:


> Otherwise, the editing form will be redisplayed with validation errors, from validation_errors field, which is itself an object, shown next to the form fields. (I don't think this accurate any more.) 

(_aus [question/type/questiontypebase.php](https://github.com/moodle/moodle/blob/07881a57720b465b76cf1957ab3fbfc754461f47/question/type/questiontypebase.php#L358-L364)_)