### PR TITLE
fix: use correct context id for package retrieval

### DIFF
--- a/classes/static_file_service.php
+++ b/classes/static_file_service.php
@@ -58,15 +58,17 @@ class static_file_service {
      * @param string $namespace
      * @param string $shortname
      * @param string $path
+     * @param int $contextid
      * @return array{ 0: string, 1: string }|null array of temporary file path and mime type or null of the file wasn't
      *                                            found
      * @throws coding_exception
      * @throws dml_exception
      * @throws invalid_dataroot_permissions
      */
-    public function download_public_static_file(string $packagehash, string $namespace, string $shortname, string $path): ?array {
+    public function download_public_static_file(string $packagehash, string $namespace, string $shortname, string $path,
+                                                int $contextid): ?array {
         $path = ltrim($path, '/');
-        $packagefileiflocal = $this->packagefileservice->get_file_by_package_hash($packagehash, context_system::instance()->id);
+        $packagefileiflocal = $this->packagefileservice->get_file_by_package_hash($packagehash, $contextid);
 
         $temppath = make_request_directory() . "/$packagehash/$namespace/$shortname/$path";
         make_writable_directory(dirname($temppath));

--- a/lib.php
+++ b/lib.php
@@ -52,7 +52,13 @@ function qtype_questionpy_pluginfile($course, $cm, $context, $filearea, $args, $
     [$packagehash, $namespace, $shortname] = $args;
     $path = implode('/', array_slice($args, 3));
 
-    [$filepath, $mimetype] = $staticfileservice->download_public_static_file($packagehash, $namespace, $shortname, $path);
+    [$filepath, $mimetype] = $staticfileservice->download_public_static_file(
+        $packagehash,
+        $namespace,
+        $shortname,
+        $path,
+        $context->id,
+    );
     if (is_null($filepath)) {
         send_file_not_found();
     }

--- a/tests/static_file_service_test.php
+++ b/tests/static_file_service_test.php
@@ -93,6 +93,8 @@ final class static_file_service_test extends \advanced_testcase {
      * @throws invalid_dataroot_permissions
      */
     public function test_should_download_public_static_file(): void {
+        global $PAGE;
+
         $hash = random_string(64);
         $this->mockhandler->append(new Response(200, [
             'Content-Type' => 'text/markdown',
@@ -102,7 +104,8 @@ final class static_file_service_test extends \advanced_testcase {
             $hash,
             'local',
             'example',
-            '/path/to/file.txt'
+            '/path/to/file.txt',
+            $PAGE->context->id,
         );
 
         $this->assertStringEqualsFile($path, 'Static file content');
@@ -125,13 +128,15 @@ final class static_file_service_test extends \advanced_testcase {
      * @throws invalid_dataroot_permissions
      */
     public function test_should_fall_back_and_warn_when_no_content_type(): void {
+        global $PAGE;
         $this->mockhandler->append(new Response(200, [], 'Static file content'));
 
         [, $mimetype] = $this->staticfileservice->download_public_static_file(
             random_string(64),
             'local',
             'example',
-            '/path/to/file.txt'
+            '/path/to/file.txt',
+            $PAGE->context->id,
         );
 
         $this->assertEquals('application/octet-stream', $mimetype);
@@ -146,13 +151,15 @@ final class static_file_service_test extends \advanced_testcase {
      * @throws moodle_exception
      */
     public function test_should_return_null_when_file_doesnt_exist(): void {
+        global $PAGE;
         $this->mockhandler->append(new Response(404, []));
 
         $result = $this->staticfileservice->download_public_static_file(
             random_string(64),
             'local',
             'example',
-            '/path/to/file.txt'
+            '/path/to/file.txt',
+            $PAGE->context->id,
         );
 
         $this->assertNull($result);


### PR DESCRIPTION
Zuvor wurde beim Aufruf von `$this->packagefileservice->get_file_by_package_hash` in `download_public_static_file` die falsche Kontext-ID übergeben, wodurch das lokale Paket nicht gefunden werden konnte. Das führte zu einer Fehlermeldung.