### PR TITLE
test: skip element tests with groups

### DIFF
--- a/tests/local/form/elements/element_html_test.php
+++ b/tests/local/form/elements/element_html_test.php
@@ -51,6 +51,13 @@ final class element_html_test extends \advanced_testcase {
      * @covers       \qtype_questionpy\local\form\qpy_renderable
      */
     public function test_rendered_html_should_match_snapshot(string $elementkind, qpy_renderable $element): void {
+        // TODO: remove when issue introduced in "MDL-61823 forms" is resolved.
+        // With the updates from "MDL-61823 forms", the fieldset-element inside the group-div-element has the same element
+        // id like the div-element itself. This causes DomDocument->loadHTML to throw an error.
+        if (in_array($elementkind, ['radio_group', 'group'])) {
+            $this->markTestSkipped();
+        }
+
         $snapshotfilepath = __DIR__ . '/html/' . $elementkind . '.html';
 
         // The sesskey is part of the form and therefore needs to be deterministic.


### PR DESCRIPTION
Wegen [MDL-61823 forms](https://git.moodle.org/gw?p=moodle.git;a=commitdiff;h=aaf84bc0cf6eb59a4496deba64af89e623f691bf) ([github](https://github.com/moodle/moodle/commit/1fca5f9f42b9306d55df9720fa61d5427d3520b3)) haben nun das Parent-`div`-Element und das `fieldset`-Element die selbe Element-ID. Aus diesem Grund schmeißt auch `\DOMDocument->loadHTML` in `test_rendered_html_should_match_snapshot` eine Exception, wodurch die Tests fehlschlagen.

Das Ganze ist kein QuestionPy-Problem, sondern kann auch bei Moodle-eigenen Fragetypen, z.B. bei "Multiple choice", beobachtet werden.

Da die Änderungen erst vor vier Tagen gemerged wurden, konnte ich vermutlich auch kein Issue dazu finden. Ich habe dazu jetzt ein [Issue im Moodle Tracker](https://tracker.moodle.org/browse/MDL-85139) erstellt.