### PR TITLE
fix(ui-renderer): account for input-element without type-attribute

### DIFF
--- a/classes/local/attempt_ui/question_ui_renderer.php
+++ b/classes/local/attempt_ui/question_ui_renderer.php
@@ -438,8 +438,8 @@ class question_ui_renderer {
         /** @var DOMElement $element */
         foreach (
             $this->xpath->query("
-                //xhtml:input[@type != 'checkbox' and @type != 'radio' and
-                              @type != 'button' and @type != 'submit' and @type != 'reset']
+                //xhtml:input[not(@type) or (@type != 'checkbox' and @type != 'radio' and
+                              @type != 'button' and @type != 'submit' and @type != 'reset')]
                 | //xhtml:select | //xhtml:textarea
                 ") as $element
         ) {


### PR DESCRIPTION
Ohne `type`-Attribute wurde das `input`-Element nicht korrekt gestylt, da das XPath in `add_styles` diese Elemente ignoriert hat.

> If this attribute is not specified, the default type adopted is `text`.

([siehe](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#input_types))