### PR TITLE
fix: question edit form

### DIFF
--- a/edit_questionpy_form.php
+++ b/edit_questionpy_form.php
@@ -418,9 +418,18 @@ class qtype_questionpy_edit_form extends question_edit_form {
 
         $question->qpy_form = $this->currentdata;
 
-        // We do not want to populate these fields based on the stored data.
-        $question->qpy_package_hash = $this->currentdata['qpy_package_hash'] ?? $this->currentdata['qpy_package_file_hash'] ?? '';
-        $question->qpy_package_selected = $this->currentdata['qpy_package_selected'] ?? false;
+        // When changing the package of a stored question, we do not want the package hash to be set in the form.
+        // Saving the question would return us to the question edit form with the package selected.
+        // Instead, we want to stay on the package selection page and show a "Required" message, indicating that a
+        // package must be selected before saving a question.
+        // The parameter `qpy_package_selected` is only present when a package was either selected or unselected.
+        // When calling the `optional_param` method while creating or editing a question, the default value `true`
+        // will be returned. This is not correct for the first case, but since `$question->qpy_package_hash` is not
+        // present when creating a new question, it does not matter.
+        $selected = $this->optional_param('qpy_package_selected', true, PARAM_BOOL);
+        if (!$selected) {
+            unset($question->qpy_package_hash);
+        }
 
         parent::set_data($question);
     }


### PR DESCRIPTION
Falls man das Paket einer bereits gespeicherten QuestionPy-Frage wechseln und anschließend, ohne ein neues Paket auszuwählen, die Frage speichern will, wurde  die Question-Edit-Form mit dem Paket angezeigt und nicht der Such-Container mit einer "Required"-Nachricht. Die bestehende Lösung hat hier durch Zufall funktioniert, da `$question->qpy_package_hash` immer auf `''` gesetzt wurde -  in `$this->currentdata` gibt es nie die Keys `qpy_package_hash`, `qpy_package_file_hash` und `qpy_package_selected`.
Das führte aber dazu, das beim Schmeißen von (Custom-)Validation-Errors, [dieser Branch](https://github.com/questionpy-org/moodle-qtype_questionpy/blob/e15933a762d582aae8c01fbbf8c47ecda16939d0/edit_questionpy_form.php#L540-L543) übersprungen wurde und das [deshalb](https://github.com/questionpy-org/moodle-qtype_questionpy/blob/e15933a762d582aae8c01fbbf8c47ecda16939d0/classes/question_service.php#L151-L153) ein Request-Error angezeigt wurde.