### PR TITLE
feat: adjust models to current QPPE

### DIFF
--- a/classes/local/api/attempt.php
+++ b/classes/local/api/attempt.php
@@ -27,7 +27,7 @@ use qtype_questionpy\local\array_converter\attributes\array_key;
  * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class attempt {
+class attempt extends localized {
     /** @var int */
     public int $variant;
 
@@ -42,11 +42,14 @@ class attempt {
     /**
      * Initializes a new instance.
      *
+     * @param string $lang
      * @param int $variant
      * @param attempt_ui $ui
      * @param package_dependency[] $packagedependencies
      */
-    public function __construct(int $variant, attempt_ui $ui, array $packagedependencies) {
+    public function __construct(string $lang, int $variant, attempt_ui $ui, array $packagedependencies) {
+        parent::__construct($lang);
+
         $this->variant = $variant;
         $this->ui = $ui;
         $this->packagedependencies = $packagedependencies;

--- a/classes/local/api/attempt_scored.php
+++ b/classes/local/api/attempt_scored.php
@@ -16,6 +16,7 @@
 
 namespace qtype_questionpy\local\api;
 
+use qtype_questionpy\local\array_converter\attributes\array_element_class;
 use qtype_questionpy\local\array_converter\attributes\array_key;
 
 /**
@@ -29,27 +30,42 @@ use qtype_questionpy\local\array_converter\attributes\array_key;
 class attempt_scored extends attempt {
     /** @var string|null */
     #[array_key('scoring_state')]
-    public ?string $scoringstate;
+    public ?string $scoringstate = null;
 
     /** @var scoring_code */
     #[array_key('scoring_code')]
     public scoring_code $scoringcode;
 
     /** @var float|null */
-    public ?float $score = null;
+    public ?float $score;
+
+    /** @var float|null */
+    #[array_key('score_adjusted')]
+    public ?float $scoreadjusted;
+
+    /** @var array<string, scored_input> */
+    #[array_key('scored_inputs')]
+    #[array_element_class(scored_input::class)]
+    public ?array $scoredinputs = [];
+
+    /** @var array<string, scored_subquestion> */
+    #[array_key('scored_subquestions')]
+    #[array_element_class(scored_subquestion::class)]
+    public ?array $scoredsubquestions;
 
     /**
      * Initializes a new instance.
      *
+     * @param string $lang
      * @param int $variant
      * @param attempt_ui $ui
      * @param scoring_code $scoringcode
      * @param string|null $scoringstate
      * @param package_dependency[] $packagedependencies
      */
-    public function __construct(int $variant, attempt_ui $ui, scoring_code $scoringcode, ?string $scoringstate,
+    public function __construct(string $lang, int $variant, attempt_ui $ui, scoring_code $scoringcode, ?string $scoringstate,
                                 array $packagedependencies) {
-        parent::__construct($variant, $ui, $packagedependencies);
+        parent::__construct($lang, $variant, $ui, $packagedependencies);
 
         $this->scoringstate = $scoringstate;
         $this->scoringcode = $scoringcode;

--- a/classes/local/api/attempt_started.php
+++ b/classes/local/api/attempt_started.php
@@ -34,13 +34,15 @@ class attempt_started extends attempt {
     /**
      * Initializes a new instance.
      *
+     * @param string $lang
      * @param int $variant
      * @param attempt_ui $ui
      * @param string $attemptstate
      * @param array $packagedependencies
      */
-    public function __construct(int $variant, attempt_ui $ui, string $attemptstate, array $packagedependencies) {
-        parent::__construct($variant, $ui, $packagedependencies);
+    public function __construct(string $lang, int $variant, attempt_ui $ui, string $attemptstate, array $packagedependencies) {
+        parent::__construct($lang, $variant, $ui, $packagedependencies);
+
         $this->attemptstate = $attemptstate;
     }
 }

--- a/classes/local/api/attempt_ui.php
+++ b/classes/local/api/attempt_ui.php
@@ -59,9 +59,9 @@ class attempt_ui {
     #[array_element_class(attempt_file::class)]
     public array $files = [];
 
-    /** @var string specifics TBD */
+    /** @var cache_control specifics TBD */
     #[array_key('cache_control')]
-    public string $cachecontrol = 'PRIVATE_CACHE';
+    public cache_control $cachecontrol = cache_control::no_cache;
 
     /**
      * Initializes a new instance.

--- a/classes/local/api/cache_control.php
+++ b/classes/local/api/cache_control.php
@@ -14,29 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\exception;
+namespace qtype_questionpy\local\api;
 
 // phpcs:ignore moodle.Commenting.InlineComment.DocBlock
 /**
- * Possible request error codes.
+ * Possible cache controls.
  *
  * @package    qtype_questionpy
  * @author     Jan Britz
  * @copyright  2025 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-enum error_code: string {
-    case package_permission_error = 'PACKAGE_PERMISSION_ERROR';
-    case queue_waiting_timeout = 'QUEUE_WAITING_TIMEOUT';
-    case worker_timeout = 'WORKER_TIMEOUT';
-    case out_of_memory = 'OUT_OF_MEMORY';
-    case invalid_attempt_state = 'INVALID_ATTEMPT_STATE';
-    case invalid_question_state = 'INVALID_QUESTION_STATE';
-    case invalid_package = 'INVALID_PACKAGE';
-    case invalid_request = 'INVALID_REQUEST';
-    case invalid_options_form = 'INVALID_OPTIONS_FORM';
-    case package_error = 'PACKAGE_ERROR';
-    case package_not_found = 'PACKAGE_NOT_FOUND';
-    case callback_api_error = 'CALLBACK_API_ERROR';
-    case server_error = 'SERVER_ERROR';
+enum cache_control: string {
+    case shared_cache = 'SHARED_CACHE';
+    case private_cache = 'PRIVATE_CACHE';
+    case no_cache = 'NO_CACHE';
 }

--- a/classes/local/api/lms_permissions.php
+++ b/classes/local/api/lms_permissions.php
@@ -14,29 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\exception;
+namespace qtype_questionpy\local\api;
 
-// phpcs:ignore moodle.Commenting.InlineComment.DocBlock
+
 /**
- * Possible request error codes.
+ * LMS specific package permissions.
  *
  * @package    qtype_questionpy
  * @author     Jan Britz
  * @copyright  2025 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-enum error_code: string {
-    case package_permission_error = 'PACKAGE_PERMISSION_ERROR';
-    case queue_waiting_timeout = 'QUEUE_WAITING_TIMEOUT';
-    case worker_timeout = 'WORKER_TIMEOUT';
-    case out_of_memory = 'OUT_OF_MEMORY';
-    case invalid_attempt_state = 'INVALID_ATTEMPT_STATE';
-    case invalid_question_state = 'INVALID_QUESTION_STATE';
-    case invalid_package = 'INVALID_PACKAGE';
-    case invalid_request = 'INVALID_REQUEST';
-    case invalid_options_form = 'INVALID_OPTIONS_FORM';
-    case package_error = 'PACKAGE_ERROR';
-    case package_not_found = 'PACKAGE_NOT_FOUND';
-    case callback_api_error = 'CALLBACK_API_ERROR';
-    case server_error = 'SERVER_ERROR';
+class lms_permissions {
+    /** @var string[] */
+    public array $attributes = [];
 }

--- a/classes/local/api/localized.php
+++ b/classes/local/api/localized.php
@@ -14,29 +14,27 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\exception;
+namespace qtype_questionpy\local\api;
 
-// phpcs:ignore moodle.Commenting.InlineComment.DocBlock
+
 /**
- * Possible request error codes.
+ * Localisation.
  *
  * @package    qtype_questionpy
  * @author     Jan Britz
  * @copyright  2025 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-enum error_code: string {
-    case package_permission_error = 'PACKAGE_PERMISSION_ERROR';
-    case queue_waiting_timeout = 'QUEUE_WAITING_TIMEOUT';
-    case worker_timeout = 'WORKER_TIMEOUT';
-    case out_of_memory = 'OUT_OF_MEMORY';
-    case invalid_attempt_state = 'INVALID_ATTEMPT_STATE';
-    case invalid_question_state = 'INVALID_QUESTION_STATE';
-    case invalid_package = 'INVALID_PACKAGE';
-    case invalid_request = 'INVALID_REQUEST';
-    case invalid_options_form = 'INVALID_OPTIONS_FORM';
-    case package_error = 'PACKAGE_ERROR';
-    case package_not_found = 'PACKAGE_NOT_FOUND';
-    case callback_api_error = 'CALLBACK_API_ERROR';
-    case server_error = 'SERVER_ERROR';
+class localized {
+    /** @var string */
+    public string $lang;
+
+    /**
+     * Initializes a new instance.
+     *
+     * @param string $lang
+     */
+    public function __construct(string $lang) {
+        $this->lang = $lang;
+    }
 }

--- a/classes/local/api/package_type.php
+++ b/classes/local/api/package_type.php
@@ -14,29 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\exception;
+namespace qtype_questionpy\local\api;
 
 // phpcs:ignore moodle.Commenting.InlineComment.DocBlock
 /**
- * Possible request error codes.
+ * Possible package types.
  *
  * @package    qtype_questionpy
  * @author     Jan Britz
  * @copyright  2025 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-enum error_code: string {
-    case package_permission_error = 'PACKAGE_PERMISSION_ERROR';
-    case queue_waiting_timeout = 'QUEUE_WAITING_TIMEOUT';
-    case worker_timeout = 'WORKER_TIMEOUT';
-    case out_of_memory = 'OUT_OF_MEMORY';
-    case invalid_attempt_state = 'INVALID_ATTEMPT_STATE';
-    case invalid_question_state = 'INVALID_QUESTION_STATE';
-    case invalid_package = 'INVALID_PACKAGE';
-    case invalid_request = 'INVALID_REQUEST';
-    case invalid_options_form = 'INVALID_OPTIONS_FORM';
-    case package_error = 'PACKAGE_ERROR';
-    case package_not_found = 'PACKAGE_NOT_FOUND';
-    case callback_api_error = 'CALLBACK_API_ERROR';
-    case server_error = 'SERVER_ERROR';
+enum package_type: string {
+    case library = 'LIBRARY';
+    case questiontype = 'QUESTIONTYPE';
+    case question = 'QUESTION';
 }

--- a/classes/local/api/question_edit_form_response.php
+++ b/classes/local/api/question_edit_form_response.php
@@ -16,6 +16,7 @@
 
 namespace qtype_questionpy\local\api;
 
+use qtype_questionpy\local\array_converter\attributes\array_element_class;
 use qtype_questionpy\local\array_converter\attributes\array_key;
 use qtype_questionpy\local\form\qpy_form;
 
@@ -34,6 +35,11 @@ class question_edit_form_response {
     /** @var array */
     #[array_key('form_data')]
     public array $formdata;
+
+    /** @var package_dependency[] */
+    #[array_key('package_dependencies')]
+    #[array_element_class(package_dependency::class)]
+    public array $packagedependencies;
 
     /**
      * Initialize a new question response.

--- a/classes/local/api/question_response.php
+++ b/classes/local/api/question_response.php
@@ -16,6 +16,7 @@
 
 namespace qtype_questionpy\local\api;
 
+use qtype_questionpy\local\array_converter\attributes\array_element_class;
 use qtype_questionpy\local\array_converter\attributes\array_key;
 
 /**
@@ -26,22 +27,26 @@ use qtype_questionpy\local\array_converter\attributes\array_key;
  * @copyright  2023 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class question_response {
+class question_response extends localized {
     /** @var string */
     #[array_key('question_state')]
     public string $state;
 
-    /** @var string */
-    #[array_key('scoring_method')]
-    public string $scoringmethod;
+    /** @var int */
+    #[array_key('num_variants')]
+    public int $numvariants = 1;
 
-    /** @var float|int */
+    /** @var float */
     #[array_key('score_min')]
     public float $scoremin = 0;
 
-    /** @var float|int */
+    /** @var float */
     #[array_key('score_max')]
     public float $scoremax = 1;
+
+    /** @var scoring_method */
+    #[array_key('scoring_method')]
+    public scoring_method $scoringmethod;
 
     /** @var float|null */
     public ?float $penalty = null;
@@ -51,20 +56,27 @@ class question_response {
     public ?float $randomguessscore = null;
 
     /** @var bool */
-    #[array_key('render_every_view')]
-    public bool $rendereveryview = false;
+    #[array_key('response_analysis_by_variant')]
+    public bool $responseanalysisbyvariant = false;
 
-    /** @var string|null */
-    #[array_key('general_feedback')]
-    public ?string $generalfeedback = null;
+    /** @var subquestion[] */
+    #[array_element_class(subquestion::class)]
+    public array $subquestions = [];
+
+    /** @var lms_permissions|null */
+    #[array_key('lms_permissions')]
+    public ?lms_permissions $lmspermissions = null;
 
     /**
      * Initialize a new question response.
      *
+     * @param string $lang
      * @param string $state new question state
-     * @param string $scoringmethod
+     * @param scoring_method $scoringmethod
      */
-    public function __construct(string $state, string $scoringmethod) {
+    public function __construct(string $lang, string $state, scoring_method $scoringmethod) {
+        parent::__construct($lang);
+
         $this->state = $state;
         $this->scoringmethod = $scoringmethod;
     }

--- a/classes/local/api/response_class.php
+++ b/classes/local/api/response_class.php
@@ -14,29 +14,23 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\exception;
+namespace qtype_questionpy\local\api;
 
-// phpcs:ignore moodle.Commenting.InlineComment.DocBlock
+use qtype_questionpy\local\array_converter\attributes\array_key;
+
 /**
- * Possible request error codes.
+ * Response class.
  *
  * @package    qtype_questionpy
  * @author     Jan Britz
  * @copyright  2025 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-enum error_code: string {
-    case package_permission_error = 'PACKAGE_PERMISSION_ERROR';
-    case queue_waiting_timeout = 'QUEUE_WAITING_TIMEOUT';
-    case worker_timeout = 'WORKER_TIMEOUT';
-    case out_of_memory = 'OUT_OF_MEMORY';
-    case invalid_attempt_state = 'INVALID_ATTEMPT_STATE';
-    case invalid_question_state = 'INVALID_QUESTION_STATE';
-    case invalid_package = 'INVALID_PACKAGE';
-    case invalid_request = 'INVALID_REQUEST';
-    case invalid_options_form = 'INVALID_OPTIONS_FORM';
-    case package_error = 'PACKAGE_ERROR';
-    case package_not_found = 'PACKAGE_NOT_FOUND';
-    case callback_api_error = 'CALLBACK_API_ERROR';
-    case server_error = 'SERVER_ERROR';
+class response_class {
+    /** @var string */
+    #[array_key('response_class')]
+    public string $responseclass;
+
+    /** @var float */
+    public float $score;
 }

--- a/classes/local/api/scored_input.php
+++ b/classes/local/api/scored_input.php
@@ -14,29 +14,21 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\exception;
+namespace qtype_questionpy\local\api;
 
-// phpcs:ignore moodle.Commenting.InlineComment.DocBlock
+
 /**
- * Possible request error codes.
+ * Scored input.
  *
  * @package    qtype_questionpy
  * @author     Jan Britz
  * @copyright  2025 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-enum error_code: string {
-    case package_permission_error = 'PACKAGE_PERMISSION_ERROR';
-    case queue_waiting_timeout = 'QUEUE_WAITING_TIMEOUT';
-    case worker_timeout = 'WORKER_TIMEOUT';
-    case out_of_memory = 'OUT_OF_MEMORY';
-    case invalid_attempt_state = 'INVALID_ATTEMPT_STATE';
-    case invalid_question_state = 'INVALID_QUESTION_STATE';
-    case invalid_package = 'INVALID_PACKAGE';
-    case invalid_request = 'INVALID_REQUEST';
-    case invalid_options_form = 'INVALID_OPTIONS_FORM';
-    case package_error = 'PACKAGE_ERROR';
-    case package_not_found = 'PACKAGE_NOT_FOUND';
-    case callback_api_error = 'CALLBACK_API_ERROR';
-    case server_error = 'SERVER_ERROR';
+class scored_input {
+    /** @var scored_input_state */
+    public scored_input_state $state;
+
+    /** @var float|null */
+    public ?float $score = null;
 }

--- a/classes/local/api/scored_input_state.php
+++ b/classes/local/api/scored_input_state.php
@@ -14,29 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\exception;
+namespace qtype_questionpy\local\api;
 
 // phpcs:ignore moodle.Commenting.InlineComment.DocBlock
 /**
- * Possible request error codes.
+ * Possible scored input states.
  *
  * @package    qtype_questionpy
  * @author     Jan Britz
  * @copyright  2025 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-enum error_code: string {
-    case package_permission_error = 'PACKAGE_PERMISSION_ERROR';
-    case queue_waiting_timeout = 'QUEUE_WAITING_TIMEOUT';
-    case worker_timeout = 'WORKER_TIMEOUT';
-    case out_of_memory = 'OUT_OF_MEMORY';
-    case invalid_attempt_state = 'INVALID_ATTEMPT_STATE';
-    case invalid_question_state = 'INVALID_QUESTION_STATE';
-    case invalid_package = 'INVALID_PACKAGE';
-    case invalid_request = 'INVALID_REQUEST';
-    case invalid_options_form = 'INVALID_OPTIONS_FORM';
-    case package_error = 'PACKAGE_ERROR';
-    case package_not_found = 'PACKAGE_NOT_FOUND';
-    case callback_api_error = 'CALLBACK_API_ERROR';
-    case server_error = 'SERVER_ERROR';
+enum scored_input_state: string {
+    case correct = 'CORRECT';
+    case consequential_score = 'CONSEQUENTIAL_SCORE';
+    case partially_correct = 'PARTIALLY_CORRECT';
+    case wrong = 'WRONG';
 }

--- a/classes/local/api/scored_subquestion.php
+++ b/classes/local/api/scored_subquestion.php
@@ -14,29 +14,36 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\exception;
+namespace qtype_questionpy\local\api;
 
-// phpcs:ignore moodle.Commenting.InlineComment.DocBlock
+
+use qtype_questionpy\local\array_converter\attributes\array_key;
+
 /**
- * Possible request error codes.
+ * Scored subquestion.
  *
  * @package    qtype_questionpy
  * @author     Jan Britz
  * @copyright  2025 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-enum error_code: string {
-    case package_permission_error = 'PACKAGE_PERMISSION_ERROR';
-    case queue_waiting_timeout = 'QUEUE_WAITING_TIMEOUT';
-    case worker_timeout = 'WORKER_TIMEOUT';
-    case out_of_memory = 'OUT_OF_MEMORY';
-    case invalid_attempt_state = 'INVALID_ATTEMPT_STATE';
-    case invalid_question_state = 'INVALID_QUESTION_STATE';
-    case invalid_package = 'INVALID_PACKAGE';
-    case invalid_request = 'INVALID_REQUEST';
-    case invalid_options_form = 'INVALID_OPTIONS_FORM';
-    case package_error = 'PACKAGE_ERROR';
-    case package_not_found = 'PACKAGE_NOT_FOUND';
-    case callback_api_error = 'CALLBACK_API_ERROR';
-    case server_error = 'SERVER_ERROR';
+class scored_subquestion {
+    /** @var float|null */
+    public ?float $score = null;
+
+    /** @var float|null */
+    #[array_key('score_adjusted')]
+    public ?float $scoreadjusted = null;
+
+    /** @var scoring_code|null */
+    #[array_key('scoring_code')]
+    public ?scoring_code $scoringcode = null;
+
+    /** @var string */
+    #[array_key('response_summary')]
+    public string $responsesummary;
+
+    /** @var string */
+    #[array_key('response_class')]
+    public string $responseclass;
 }

--- a/classes/local/api/scoring_method.php
+++ b/classes/local/api/scoring_method.php
@@ -14,29 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\exception;
+namespace qtype_questionpy\local\api;
 
 // phpcs:ignore moodle.Commenting.InlineComment.DocBlock
 /**
- * Possible request error codes.
+ * Possible scoring methods.
  *
  * @package    qtype_questionpy
  * @author     Jan Britz
  * @copyright  2025 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-enum error_code: string {
-    case package_permission_error = 'PACKAGE_PERMISSION_ERROR';
-    case queue_waiting_timeout = 'QUEUE_WAITING_TIMEOUT';
-    case worker_timeout = 'WORKER_TIMEOUT';
-    case out_of_memory = 'OUT_OF_MEMORY';
-    case invalid_attempt_state = 'INVALID_ATTEMPT_STATE';
-    case invalid_question_state = 'INVALID_QUESTION_STATE';
-    case invalid_package = 'INVALID_PACKAGE';
-    case invalid_request = 'INVALID_REQUEST';
-    case invalid_options_form = 'INVALID_OPTIONS_FORM';
-    case package_error = 'PACKAGE_ERROR';
-    case package_not_found = 'PACKAGE_NOT_FOUND';
-    case callback_api_error = 'CALLBACK_API_ERROR';
-    case server_error = 'SERVER_ERROR';
+enum scoring_method: string {
+    case always_manual_scoring_required = 'ALWAYS_MANUAL_SCORING_REQUIRED';
+    case automatically_scorable = 'AUTOMATICALLY_SCORABLE';
+    case automatically_scorable_with_score_adjustment = 'AUTOMATICALLY_SCORABLE_WITH_SCORE_ADJUSTMENT';
 }

--- a/classes/local/api/subquestion.php
+++ b/classes/local/api/subquestion.php
@@ -14,29 +14,30 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace qtype_questionpy\exception;
+namespace qtype_questionpy\local\api;
 
-// phpcs:ignore moodle.Commenting.InlineComment.DocBlock
+use qtype_questionpy\local\array_converter\attributes\array_element_class;
+use qtype_questionpy\local\array_converter\attributes\array_key;
+
 /**
- * Possible request error codes.
+ * Subquestion.
  *
  * @package    qtype_questionpy
  * @author     Jan Britz
  * @copyright  2025 TU Berlin, innoCampus {@link https://www.questionpy.org}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-enum error_code: string {
-    case package_permission_error = 'PACKAGE_PERMISSION_ERROR';
-    case queue_waiting_timeout = 'QUEUE_WAITING_TIMEOUT';
-    case worker_timeout = 'WORKER_TIMEOUT';
-    case out_of_memory = 'OUT_OF_MEMORY';
-    case invalid_attempt_state = 'INVALID_ATTEMPT_STATE';
-    case invalid_question_state = 'INVALID_QUESTION_STATE';
-    case invalid_package = 'INVALID_PACKAGE';
-    case invalid_request = 'INVALID_REQUEST';
-    case invalid_options_form = 'INVALID_OPTIONS_FORM';
-    case package_error = 'PACKAGE_ERROR';
-    case package_not_found = 'PACKAGE_NOT_FOUND';
-    case callback_api_error = 'CALLBACK_API_ERROR';
-    case server_error = 'SERVER_ERROR';
+class subquestion {
+    /** @var string */
+    #[array_key('subquestion_id')]
+    public string $subquestionid;
+
+    /** @var float|null */
+    #[array_key('score_max')]
+    public ?float $scoremax;
+
+    /** @var response_class[]|null */
+    #[array_key('response_classes')]
+    #[array_element_class(response_class::class)]
+    public ?array $responseclasses;
 }

--- a/classes/local/package/package.php
+++ b/classes/local/package/package.php
@@ -19,6 +19,7 @@ namespace qtype_questionpy\local\package;
 use dml_exception;
 use moodle_exception;
 use qtype_questionpy\last_used_service;
+use qtype_questionpy\local\api\package_type;
 use qtype_questionpy\local\array_converter\array_converter;
 
 /**
@@ -43,7 +44,7 @@ class package extends package_base {
      * @param string $shortname
      * @param string $namespace
      * @param array $name
-     * @param string $type
+     * @param package_type $type
      * @param string|null $author
      * @param string|null $url
      * @param array|null $languages
@@ -52,7 +53,7 @@ class package extends package_base {
      * @param string|null $license
      * @param array|null $tags
      */
-    public function __construct(int $id, string $shortname, string $namespace, array $name, string $type,
+    public function __construct(int $id, string $shortname, string $namespace, array $name, package_type $type,
                                 ?string $author = null, ?string $url = null, ?array $languages = null,
                                 ?array $description = null, ?string $icon = null, ?string $license = null,
                                 ?array $tags = null) {

--- a/classes/local/package/package_base.php
+++ b/classes/local/package/package_base.php
@@ -17,6 +17,7 @@
 namespace qtype_questionpy\local\package;
 
 use moodle_exception;
+use qtype_questionpy\local\api\package_type;
 use qtype_questionpy\local\array_converter\array_converter;
 use qtype_questionpy\local\array_converter\attributes\array_alias;
 use qtype_questionpy\local\array_converter\attributes\array_key;
@@ -47,9 +48,9 @@ class package_base {
     public readonly array $name;
 
     /**
-     * @var string package type
+     * @var package_type package type
      */
-    public readonly string $type;
+    public readonly package_type $type;
 
     /**
      * @var string|null package author
@@ -92,7 +93,7 @@ class package_base {
      * @param string $shortname
      * @param string $namespace
      * @param array $name
-     * @param string $type
+     * @param package_type $type
      * @param string|null $author
      * @param string|null $url
      * @param array|null $languages
@@ -101,7 +102,7 @@ class package_base {
      * @param string|null $license
      * @param array|null $tags
      */
-    public function __construct(string $shortname, string $namespace, array $name, string $type,
+    public function __construct(string $shortname, string $namespace, array $name, package_type $type,
                                 ?string $author = null, ?string $url = null, ?array $languages = null,
                                 ?array $description = null, ?string $icon = null, ?string $license = null,
                                 ?array $tags = null) {

--- a/classes/local/package/package_info.php
+++ b/classes/local/package/package_info.php
@@ -72,7 +72,7 @@ class package_info extends package_base {
         $id = $DB->insert_record('qtype_questionpy_package', [
             'shortname' => $this->shortname,
             'namespace' => $this->namespace,
-            'type' => $this->type,
+            'type' => $this->type->value,
             'author' => $this->author,
             'url' => $this->url,
             'icon' => $this->icon,
@@ -123,7 +123,7 @@ class package_info extends package_base {
         $transaction = $DB->start_delegated_transaction();
         $DB->update_record('qtype_questionpy_package', [
             'id' => $id,
-            'type' => $this->type,
+            'type' => $this->type->value,
             'author' => $this->author,
             'url' => $this->url,
             'icon' => $this->icon,

--- a/tests/data_provider.php
+++ b/tests/data_provider.php
@@ -25,6 +25,7 @@
 namespace qtype_questionpy;
 
 use moodle_exception;
+use qtype_questionpy\local\api\package_type;
 use qtype_questionpy\local\array_converter\array_converter;
 use qtype_questionpy\local\form\conditions\does_not_equal;
 use qtype_questionpy\local\form\conditions\equals;
@@ -63,7 +64,7 @@ function package_versions_info_provider(?array $packageinfo = null, ?array $vers
             'en' => 'en: My Name',
             'de' => 'de: My Name',
         ],
-        'type' => 'questiontype',
+        'type' => package_type::questiontype->value,
         'author' => 'John Doe',
         'url' => 'https://www.example.com/',
         'languages' => ['en', 'de'],

--- a/tests/local/package/package_base_test.php
+++ b/tests/local/package/package_base_test.php
@@ -16,6 +16,8 @@
 
 namespace qtype_questionpy\local\package;
 
+use qtype_questionpy\local\api\package_type;
+
 /**
  * Unit tests for the questionpy package_base class.
  *
@@ -32,7 +34,7 @@ final class package_base_test extends \advanced_testcase {
      */
     public function test_get_localized_name(): void {
         $name = ['en' => 'english_name', 'de' => 'german_name', 'fr' => 'french_name'];
-        $package = new package_base('shortname', 'default', $name, 'question');
+        $package = new package_base('shortname', 'default', $name, package_type::questiontype);
 
         // Every language in package exists in preferred language.
         $languages = ['en', 'de', 'fr'];
@@ -48,7 +50,7 @@ final class package_base_test extends \advanced_testcase {
 
         // Preferred language and fallback language in package does not exist.
         $name = ['de' => 'german_name', 'fr' => 'french_name'];
-        $package = new package_base('shortname', 'default', $name, 'question');
+        $package = new package_base('shortname', 'default', $name, package_type::questiontype);
         $this->assertEquals($name['de'], $package->get_localized_name($languages));
     }
 
@@ -64,7 +66,7 @@ final class package_base_test extends \advanced_testcase {
             'shortname',
             'default',
             ['en' => 'english_name'],
-            'question',
+            package_type::questiontype,
             'author',
             'url',
             [],
@@ -89,7 +91,7 @@ final class package_base_test extends \advanced_testcase {
             'shortname',
             'default',
             ['en' => 'english_name'],
-            'question',
+            package_type::questiontype,
             'author',
             'url',
             [],
@@ -103,7 +105,7 @@ final class package_base_test extends \advanced_testcase {
             'shortname',
             'default',
             ['en' => 'english_name'],
-            'question',
+            package_type::questiontype,
             'author',
             'url',
             [],
@@ -117,7 +119,7 @@ final class package_base_test extends \advanced_testcase {
             'shortname',
             'default',
             ['en' => 'english_name'],
-            'question',
+            package_type::questiontype,
             'author',
             'url',
             [],

--- a/tests/local/package/package_raw_test.php
+++ b/tests/local/package/package_raw_test.php
@@ -17,6 +17,7 @@
 namespace qtype_questionpy\local\package;
 
 use moodle_exception;
+use qtype_questionpy\local\api\package_type;
 use qtype_questionpy\local\array_converter\array_converter;
 
 defined('MOODLE_INTERNAL') || die;
@@ -45,7 +46,7 @@ final class package_raw_test extends \advanced_testcase {
                     'namespace' => 'namespace',
                     'name' => [],
                     'version' => '1.0.0',
-                    'type' => 'question',
+                    'type' => package_type::questiontype->value,
                 ],
             ],
             'Maximal package data' => [
@@ -55,7 +56,7 @@ final class package_raw_test extends \advanced_testcase {
                     'namespace' => 'namespace',
                     'name' => [],
                     'version' => '1.0.0',
-                    'type' => 'question',
+                    'type' => package_type::questiontype->value,
 
                     'author' => 'author',
                     'url' => 'url',
@@ -73,7 +74,7 @@ final class package_raw_test extends \advanced_testcase {
                     'namespace' => 'namespace',
                     'name' => [],
                     'version' => '1.0.0',
-                    'type' => 'question',
+                    'type' => package_type::questiontype->value,
                     'tags' => ['tag1', 'tag2'],
                 ],
             ],
@@ -84,7 +85,7 @@ final class package_raw_test extends \advanced_testcase {
                     'namespace' => 'namespace',
                     'name' => ['en' => 'en_name'],
                     'version' => '1.0.0',
-                    'type' => 'question',
+                    'type' => package_type::questiontype->value,
                     'languages' => ['en'],
                     'description' => ['en' => 'en_description'],
                 ],
@@ -96,7 +97,7 @@ final class package_raw_test extends \advanced_testcase {
                     'namespace' => 'namespace',
                     'name' => ['en' => 'en_name', 'de' => 'de_name', 'fr' => 'fr_name'],
                     'version' => '1.0.0',
-                    'type' => 'question',
+                    'type' => package_type::questiontype->value,
                     'languages' => ['en', 'de', 'fr'],
                     'description' => ['en' => 'en_description', 'de' => 'de_description', 'fr' => 'fr_description'],
                 ],
@@ -108,7 +109,7 @@ final class package_raw_test extends \advanced_testcase {
                     'namespace' => 'namespace',
                     'name' => ['en' => 'en_name', 'de' => 'de_name', 'fr' => 'fr_name'],
                     'version' => '1.0.0',
-                    'type' => 'question',
+                    'type' => package_type::questiontype->value,
                     'languages' => ['en', 'de', 'fr'],
                     'description' => ['en' => 'en_description', 'de' => 'de_description', 'fr' => 'fr_description'],
                     'tags' => ['tag1', 'tag2'],

--- a/tests/local/package/package_test.php
+++ b/tests/local/package/package_test.php
@@ -17,6 +17,7 @@
 namespace qtype_questionpy\local\package;
 
 use moodle_exception;
+use qtype_questionpy\local\api\package_type;
 use function qtype_questionpy\package_versions_info_provider;
 
 defined('MOODLE_INTERNAL') || die;
@@ -146,8 +147,8 @@ final class package_test extends \advanced_testcase {
      * @return void
      */
     public function test_difference_from(): void {
-        $package1 = new package(0, 'shortname', 'namespace', [], 'type', 'author', 'url', ['en', 'de']);
-        $package2 = new package(1, 'shortname', 'namespace', [], 'type', 'author', 'url', ['de', 'en']);
+        $package1 = new package(0, 'shortname', 'namespace', [], package_type::questiontype, 'author', 'url', ['en', 'de']);
+        $package2 = new package(1, 'shortname', 'namespace', [], package_type::questiontype, 'author', 'url', ['de', 'en']);
 
         $difference = $package1->difference_from($package2);
         $this->assertEmpty($difference);

--- a/tests/question_service_test.php
+++ b/tests/question_service_test.php
@@ -25,7 +25,9 @@ use dml_exception;
 use moodle_exception;
 use qtype_questionpy\local\api\api;
 use qtype_questionpy\local\api\package_api;
+use qtype_questionpy\local\api\package_type;
 use qtype_questionpy\local\api\question_response;
+use qtype_questionpy\local\api\scoring_method;
 use qtype_questionpy\local\array_converter\array_converter;
 use qtype_questionpy\local\package\package;
 use qtype_questionpy\local\package\package_raw;
@@ -119,7 +121,7 @@ final class question_service_test extends \advanced_testcase {
             ->expects($this->once())
             ->method('create_question')
             ->with($oldstate, (object) $formdata)
-            ->willReturn(new question_response($newstate, ''));
+            ->willReturn(new question_response('en', $newstate, scoring_method::automatically_scorable));
 
         $this->questionservice->upsert_question(
             (object)[
@@ -157,7 +159,7 @@ final class question_service_test extends \advanced_testcase {
             ->expects($this->once())
             ->method('create_question')
             ->with($oldstate, (object) $formdata)
-            ->willReturn(new question_response($oldstate, ''));
+            ->willReturn(new question_response('en', $oldstate, scoring_method::automatically_scorable));
 
         $this->questionservice->upsert_question(
             (object)[
@@ -200,7 +202,7 @@ final class question_service_test extends \advanced_testcase {
             ->expects($this->once())
             ->method('create_question')
             ->with(null, (object) $formdata)
-            ->willReturn(new question_response($newstate, ''));
+            ->willReturn(new question_response('en', $newstate, scoring_method::automatically_scorable));
 
         $this->questionservice->upsert_question(
             (object)[
@@ -228,7 +230,13 @@ final class question_service_test extends \advanced_testcase {
         $hash = hash('sha256', rand());
         $rawpackage = array_converter::from_array(
             package_raw::class,
-            ['package_hash' => $hash, 'short_name' => 'sn', 'namespace' => 'ns', 'name' => ['en' => 'name'], 'type' => 'X']
+            [
+                'package_hash' => $hash,
+                'short_name' => 'sn',
+                'namespace' => 'ns',
+                'name' => ['en' => 'name'],
+                'type' => package_type::questiontype->value,
+            ],
         );
 
         // Retrieve the package data from the application serve.
@@ -245,7 +253,7 @@ final class question_service_test extends \advanced_testcase {
             ->expects($this->once())
             ->method('create_question')
             ->with(null, (object) $formdata)
-            ->willReturn(new question_response($newstate, ''));
+            ->willReturn(new question_response('en', $newstate, scoring_method::automatically_scorable));
 
         $this->questionservice->upsert_question(
             (object)[
@@ -285,7 +293,7 @@ final class question_service_test extends \advanced_testcase {
             ->expects($this->once())
             ->method('create_question')
             ->with(null, (object) $formdata)
-            ->willReturn(new question_response($newstate, ''));
+            ->willReturn(new question_response('en', $newstate, scoring_method::automatically_scorable));
 
         $this->questionservice->upsert_question(
             (object)[
@@ -327,7 +335,7 @@ final class question_service_test extends \advanced_testcase {
             ->expects($this->exactly(2))
             ->method('create_question')
             ->with(null, (object) $formdata)
-            ->willReturn(new question_response($newstate, ''));
+            ->willReturn(new question_response('en', $newstate, scoring_method::automatically_scorable));
 
         $this->questionservice->upsert_question(
             (object)[


### PR DESCRIPTION
Um #203 zu bearbeiten, müssen die Models im Plugin an die letzten Änderungen der QPPE (https://github.com/questionpy-org/questionpy-server/pull/181) angepasst werden.

Dabei ist mir aufgefallen, dass es mittlerweile viele Unterschiede zwischen den Models und der QPPE gibt.