### PR TITLE
fix: minor bugs

### DIFF
--- a/classes/local/form/elements/hidden_element.php
+++ b/classes/local/form/elements/hidden_element.php
@@ -54,7 +54,7 @@ class hidden_element extends form_element {
      */
     public function render_to(render_context $context): void {
         $context->add_element('hidden', $this->name, $this->value);
-        $context->set_type($this->name, PARAM_TEXT);
+        $context->set_type($this->name, PARAM_RAW);
 
         $this->render_conditions($context, $this->name);
     }

--- a/classes/local/form/elements/text_input_element.php
+++ b/classes/local/form/elements/text_input_element.php
@@ -83,7 +83,7 @@ class text_input_element extends form_element {
             $context->contextualize($this->label),
             $attributes
         );
-        $context->set_type($this->name, PARAM_TEXT);
+        $context->set_type($this->name, PARAM_RAW);
 
         if ($this->default) {
             $context->set_default($this->name, $context->contextualize($this->default));

--- a/edit_questionpy_form.php
+++ b/edit_questionpy_form.php
@@ -479,7 +479,7 @@ class qtype_questionpy_edit_form extends question_edit_form {
             foreach ($errorswithnoelement as $element => $error) {
                 $listitems[] = get_string('options_form_validation_error_element', 'qtype_questionpy', [
                     'name' => $element,
-                    'error' => $error,
+                    'error' => s($error),
                 ]);
             }
             $list = html_writer::alist($listitems);


### PR DESCRIPTION
Beim Testen des `truthtable`-Pakets sind mir zwei Punkte aufgefallen:
- 06f0948a4e65bbf8354bdc49a29a9fd1e2c5c6cf: Das `text_input_element` hat die Formel `x <-> y` zu `x  y` gecleant, da `<->` als HTML-Tag erkannt wird. Gleiches gilt auch für das `hidden_element`.
- 674723405f64cd5938c2e29e49a1accdab0dcba2: Fehlermeldungen wurden nicht escapt.