### PR TITLE
Fix closing HTML tags in iframe and restore old value

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -162,9 +162,10 @@ class qtype_questionpy_renderer extends qtype_renderer {
     protected function get_iframe_document(context $context, qtype_questionpy_question $question, callable $contentcb): string {
         // We know what we are doing here. We are touching these globals on purpose.
         // phpcs:disable moodle.PHP.ForbiddenGlobalUse.BadGlobal
-        global $PAGE, $OUTPUT;
+        global $CFG, $PAGE, $OUTPUT;
         $oldpage = $PAGE;
         $oldoutput = $OUTPUT;
+        $oldclosingtags = $CFG->closingtags ?? '';
 
         // Initialize output buffer.
         // We do this to ensure that any echo, var_dump, etc. statements are included in the iframe contents.
@@ -197,9 +198,12 @@ class qtype_questionpy_renderer extends qtype_renderer {
             echo $this->get_package_css_links($question->ui->cssfiles, $question);
             echo $iframecontents;
             echo $OUTPUT->footer();
+            // The function $OUTPUT->footer stores the HTML closing tags in this global.
+            echo $CFG->closingtags ?? '';
         } finally {
             $PAGE = $oldpage;
             $OUTPUT = $oldoutput;
+            $CFG->closingtags = $oldclosingtags;
         }
         // phpcs:enable
 


### PR DESCRIPTION
Im assignsubmission_qpy Plugin habe ich das Problem entdeckt, dass auf der Grading-Seite ein Fehler `JSON.parse: unexpected non-whitespace character after JSON data at line 1 column 149319 of the JSON data` kommt. Das hängt mit der `$OUTPUT->footer` Funktion zusammen, die die schließenden HTML-Tags `</body></html>` in `$CFG->closingtags` packt statt sie sofort auszugeben. Dadurch landen diese schließenden Tags nicht im iframe src sondern werden in diesem konkreten Fall an ein JSON angehängt, wo es nicht hingehört.