### PR TITLE
fix: various adjustments

### DIFF
--- a/classes/external/search_packages.php
+++ b/classes/external/search_packages.php
@@ -315,7 +315,7 @@ class search_packages extends external_api {
      * @throws moodle_exception
      */
     private static function create_sql($params): array {
-        global $USER;
+        global $USER, $OUTPUT;
 
         // Order the results.
         $isrecentylusedcategory = $params['category'] === 'recentlyused';
@@ -335,8 +335,12 @@ class search_packages extends external_api {
         $ufservice = \core_favourites\service_factory::get_service_for_user_context($usercontext);
         [$joinfavsql, $joinfavparams] = $ufservice->get_join_sql_by_type('qtype_questionpy', 'package', 'f', 'p.id');
 
+        // When a package does not provide an icon we use the QuestionPy logo as a fallback.
+        $placeholdericon = $OUTPUT->image_url('icon', 'qtype_questionpy')->out();
+        $placeholdericonparam = ['placeholdericon' => $placeholdericon];
+
         // Merge existing parameters.
-        $finalparams = array_merge($joinlangsparams, $wheretagsparams, $wherelikeparams, $joinfavparams);
+        $finalparams = array_merge($joinlangsparams, $wheretagsparams, $wherelikeparams, $joinfavparams, $placeholdericonparam);
 
         // Search through recently used packages if the category is set.
         $selecttimeusedsql = '';
@@ -356,7 +360,8 @@ class search_packages extends external_api {
 
         // Assemble final sql query.
         $finalsql = "
-            SELECT id, short_name, namespace, author, url, icon, license, name, description, isfavourite
+            SELECT id, short_name, namespace, author, url, COALESCE(icon, :placeholdericon) as icon, license, name, description,
+                   isfavourite
             FROM (
                 SELECT DISTINCT p.id, p.shortname AS short_name, p.namespace, p.author, p.url, p.icon, p.license,
                                 $coalescenamesql AS name, $coalescedescsql AS description, p.timecreated $selecttimeusedsql,

--- a/classes/question_service.php
+++ b/classes/question_service.php
@@ -139,7 +139,9 @@ class question_service {
                 $pkgversionhash = $pkgversion->hash;
                 $pkgversionnamespace = $package->namespace;
                 $pkgversionshortname = $package->shortname;
-                last_used_service::add($question->context->get_course_context()->id, $package->id);
+                $coursecontext = $question->context->get_course_context(strict: false);
+                $context = $coursecontext ?: $question->context;
+                last_used_service::add($context->id, $package->id);
             } else {
                 $packageinfo = $this->api->get_package_info($question->qpy_package_hash);
                 $pkgversionhash = $packageinfo->hash;

--- a/classes/question_service.php
+++ b/classes/question_service.php
@@ -139,7 +139,7 @@ class question_service {
                 $pkgversionhash = $pkgversion->hash;
                 $pkgversionnamespace = $package->namespace;
                 $pkgversionshortname = $package->shortname;
-                last_used_service::add($question->context->id, $package->id);
+                last_used_service::add($question->context->get_course_context()->id, $package->id);
             } else {
                 $packageinfo = $this->api->get_package_info($question->qpy_package_hash);
                 $pkgversionhash = $packageinfo->hash;

--- a/edit_questionpy_form.php
+++ b/edit_questionpy_form.php
@@ -221,6 +221,7 @@ class qtype_questionpy_edit_form extends question_edit_form {
         $packagearray['islocal'] = !is_null($file);
         $packagearray['isfavourite'] = $isfavourite;
         $packagearray['ismarkableasfavourite'] = !is_null($isfavourite);
+        $packagearray['icon'] ??= $OUTPUT->image_url('icon', 'qtype_questionpy')->out();
 
         // Create a group which contains the package element - the group is used to simplify the styling.
         $group[] = $mform->createElement(

--- a/edit_questionpy_form.php
+++ b/edit_questionpy_form.php
@@ -185,9 +185,12 @@ class qtype_questionpy_edit_form extends question_edit_form {
 
         // Create a group which contains the package container - the group is used to simplify the styling.
         // TODO: get limit from settings.
+        $coursecontext = $this->context->get_course_context(strict: false);
+        $context = $coursecontext ?: $this->context;
+
         $group[] = $mform->createElement('html', $OUTPUT->render_from_template(
             'qtype_questionpy/package_search/area',
-            ['contextid' => $this->context->get_course_context()->id, 'limit' => 10]
+            ['contextid' => $context->id, 'limit' => 10]
         ));
         $mform->addGroup($group, 'qpy_package_container');
         $mform->hideIf('qpy_package_container', 'qpy_package_source', 'neq', 'search');

--- a/lang/en/qtype_questionpy.php
+++ b/lang/en/qtype_questionpy.php
@@ -49,6 +49,7 @@ $string['mark_as_favourite'] = 'Favourite';
 $string['max_package_size_kb'] = 'Maximum file size of a QuestionPy package';
 $string['max_package_size_kb_description'] = 'Maximum file size in kB';
 $string['missing_select_option'] = '(the selected option is no longer available)';
+$string['no_actions_available'] = 'No actions available';
 $string['open_website'] = 'Open website';
 $string['options_form_validation_error_element'] = '{$a->name}: {$a->error}';
 $string['options_form_validation_error_title'] = 'The following errors occurred while validating the form and could not'

--- a/styles.css
+++ b/styles.css
@@ -84,8 +84,8 @@ body.questionpy-iframe-body .que .content {
 }
 
 .qpy-card {
-    border: 1px solid var(--secondary);
-    background-color: var(--light);
+    border: 1px solid var(--bs-secondary);
+    background-color: var(--bs-light);
     display: flex;
     gap: 10px;
     align-items: stretch;
@@ -297,8 +297,8 @@ body.questionpy-iframe-body .que .content {
 }
 
 .qpy-state-view {
-    border: 1px solid var(--secondary);
-    background-color: var(--light);
+    border: 1px solid var(--bs-secondary);
+    background-color: var(--bs-light);
     padding: 0.5rem;
     margin-bottom: 1rem;
     overflow: auto;

--- a/templates/package/package_base.mustache
+++ b/templates/package/package_base.mustache
@@ -48,8 +48,8 @@
             <button
               type="button"
               class="qpy-show-more-button btn btn-sm btn-link p-0 d-none collapsed"
-              data-toggle="collapse"
-              data-target="#collapse-{{uniqid}}"
+              data-bs-toggle="collapse"
+              data-bs-target="#collapse-{{uniqid}}"
               aria-expanded="false"
               aria-controls="collapse-{{uniqid}}"
             >

--- a/templates/package/package_selection.mustache
+++ b/templates/package/package_selection.mustache
@@ -65,8 +65,8 @@
                     {{/versions}}
                 </select>
                 <div class="dropdown">
-                    <a role="button" data-toggle="dropdown" aria-expanded="false">
-                        {{#pix}} i/moremenu {{/pix}}
+                    <a class="text-body text-decoration-none" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                        <i class="fa fa-ellipsis"></i>
                     </a>
                     <div class="dropdown-menu">
                         {{#ismarkableasfavourite}}
@@ -96,14 +96,14 @@
             {{#isselected}}
                 <div>
                     {{#islocal}}
-                        <span class="badge badge-info user-select-none mr-auto mb-2" data-toggle="tooltip" data-placement="top" data-title="{{#cleanstr}} selection_custom_package_text, qtype_questionpy {{/cleanstr}}">
+                        <span class="badge badge-info user-select-none mr-auto mb-2" data-bs-toggle="tooltip" data-bs-placement="top" data-title="{{#cleanstr}} selection_custom_package_text, qtype_questionpy {{/cleanstr}}">
                             &#9432; {{#str}} selection_custom_package_header, qtype_questionpy {{/str}}
                         </span>
                     {{/islocal}}
                     {{^islocal}}
                         {{^ismarkableasfavourite}}
                             {{! This package was previously in the database. }}
-                            <span class="badge badge-info user-select-none mr-auto mb-2" data-toggle="tooltip" data-placement="top" data-title="{{#cleanstr}} selection_package_no_longer_in_database_text, qtype_questionpy {{/cleanstr}}">
+                            <span class="badge badge-info user-select-none mr-auto mb-2" data-bs-toggle="tooltip" data-placement="top" data-title="{{#cleanstr}} selection_package_no_longer_in_database_text, qtype_questionpy {{/cleanstr}}">
                                 &#9432; {{#str}} selection_package_no_longer_in_database_header, qtype_questionpy {{/str}}
                             </span>
                         {{/ismarkableasfavourite}}

--- a/templates/package/package_selection.mustache
+++ b/templates/package/package_selection.mustache
@@ -82,10 +82,11 @@
                         {{#url}}
                             <a class="dropdown-item" href="{{url}}" target="_blank">{{#pix}} i/mnethost {{/pix}}{{#str}} open_website, qtype_questionpy {{/str}}</a>
                         {{/url}}
-                        {{^url}}
-                            {{! TODO: Remove when a menu item is added which is always present - this is only a placeholder. }}
-                            <a class="dropdown-item" href="https://example.com/" target="_blank">{{#pix}} i/mnethost {{/pix}}{{#str}} open_website, qtype_questionpy {{/str}}</a>
-                        {{/url}}
+                        {{^ismarkableasfavourite}}
+                            {{^url}}
+                                <p class="text-center mb-0">{{#str}} no_actions_available, qtype_questionpy {{/str}}</p>
+                            {{/url}}
+                        {{/ismarkableasfavourite}}
                     </div>
                 </div>
             </div>

--- a/templates/package_search/area.mustache
+++ b/templates/package_search/area.mustache
@@ -53,9 +53,9 @@
     <div data-for="package-container" class="qpy-package-search-container">
         <nav>
             <div class="nav nav-tabs" role="tablist">
-                <button class="nav-link active" data-for="all-header" id="qpy-all-header-{{uniqid}}" data-toggle="tab" data-target="#qpy-all-content-{{uniqid}}" type="button" role="tab" aria-controls="qpy-all-content-{{uniqid}}" aria-selected="true">{{#cleanstr}} search_all_header, qtype_questionpy, 0 {{/cleanstr}}</button>
-                <button class="nav-link" data-for="recentlyused-header" id="qpy-recently-used-header-{{uniqid}}" data-toggle="tab" data-target="#qpy-recently-used-content-{{uniqid}}" type="button" role="tab" aria-controls="qpy-recently-used-content-{{uniqid}}" aria-selected="false">{{#cleanstr}} search_recentlyused_header, qtype_questionpy, 0 {{/cleanstr}}</button>
-                <button class="nav-link" data-for="favourites-header" id="qpy-favourites-header-{{uniqid}}" data-toggle="tab" data-target="#qpy-favourites-content-{{uniqid}}" type="button" role="tab" aria-controls="qpy-favourites-content-{{uniqid}}" aria-selected="false">{{#cleanstr}} search_favourites_header, qtype_questionpy, 0 {{/cleanstr}}</button>
+                <button class="nav-link active" data-for="all-header" id="qpy-all-header-{{uniqid}}" data-bs-toggle="tab" data-bs-target="#qpy-all-content-{{uniqid}}" type="button" role="tab" aria-controls="qpy-all-content-{{uniqid}}" aria-selected="true">{{#cleanstr}} search_all_header, qtype_questionpy, 0 {{/cleanstr}}</button>
+                <button class="nav-link" data-for="recentlyused-header" id="qpy-recently-used-header-{{uniqid}}" data-bs-toggle="tab" data-bs-target="#qpy-recently-used-content-{{uniqid}}" type="button" role="tab" aria-controls="qpy-recently-used-content-{{uniqid}}" aria-selected="false">{{#cleanstr}} search_recentlyused_header, qtype_questionpy, 0 {{/cleanstr}}</button>
+                <button class="nav-link" data-for="favourites-header" id="qpy-favourites-header-{{uniqid}}" data-bs-toggle="tab" data-bs-target="#qpy-favourites-content-{{uniqid}}" type="button" role="tab" aria-controls="qpy-favourites-content-{{uniqid}}" aria-selected="false">{{#cleanstr}} search_favourites_header, qtype_questionpy, 0 {{/cleanstr}}</button>
                 <div class="ml-auto my-auto qpy-loading-indicator">
                     {{> core/loading }}
                 </div>

--- a/templates/package_search/sort.mustache
+++ b/templates/package_search/sort.mustache
@@ -30,7 +30,7 @@
     {}
 }}
 <div class="d-flex justify-content-end">
-    <select class="custom-select custom-select-sm" data-for="sort" aria-label="{{#cleanstr}} search_sort_label_aria, qtype_questionpy {{/cleanstr}}">
+    <select class="form-select form-select-sm" data-for="sort" aria-label="{{#cleanstr}} search_sort_label_aria, qtype_questionpy {{/cleanstr}}">
         <option data-sort="alpha" data-order="asc" selected>&#9650; {{#str}} search_sort_alphabetical, qtype_questionpy {{/str}}</option>
         <option data-sort="alpha" data-order="desc">&#9660; {{#str}} search_sort_alphabetical, qtype_questionpy {{/str}}</option>
         <option data-sort="date" data-order="asc">&#9650; {{#str}} search_sort_creation_date, qtype_questionpy {{/str}}</option>


### PR DESCRIPTION
- 2535163bf8f1bb35a94272d697a40b1ef06c6d82: Anpassung an Bootstrap 5. Dadurch funktioniert auch wieder der Suchcontainer. Unter Moodle 4.5 sollte dieser dann aber nicht mehr funktionieren.
- 028ca18bad6be6142d338875d89a4ae2d5111427: Damit funktioniert der "Recently Used"-Tab wieder. Wir sind irgendwann mal auf die Kurskontext-ID umgestiegen.
- 3b80505a1387fe5f9ab53153afef42958ed06c30: Entfernung des Platzhalters und Anzeige einer kurzen Nachricht, wenn keine Aktionen im Dropdown-Menü verfügbar sind.
- fd48b82b387ca6cba7e43c2110411cff0608c938: Mit Kontexten außerhalb eines Kurses arbeiten. Eigentlich sollten Quizze immer in einem Kurskontext liegen, in Tests ist das z.B. nicht der Fall.