### PR TITLE
User den Download von response_files erlauben

### DIFF
--- a/classes/local/attempt_ui/qpy_file_upload.php
+++ b/classes/local/attempt_ui/qpy_file_upload.php
@@ -61,6 +61,7 @@ class qpy_file_upload {
      */
     public function get_limits_in(context $context): validatable_upload_limits {
         global $CFG, $PAGE;
+        require_once($CFG->libdir . '/formslib.php'); // For EDITOR_UNLIMITED_FILES.
 
         $maxfiles = $this->element->getAttribute('max-files');
         $maxfiles = is_numeric($maxfiles) ? intval($maxfiles) : EDITOR_UNLIMITED_FILES;

--- a/question.php
+++ b/question.php
@@ -442,6 +442,29 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
     }
 
     /**
+     * Checks whether the user is allowed to be served a particular file.
+     *
+     * @param question_attempt $qa the question attempt being displayed.
+     * @param question_display_options $options the options that control display of the question.
+     * @param string $component the name of the component we are serving files for.
+     * @param string $filearea the name of the file area.
+     * @param array $args the remaining bits of the file path.
+     * @param bool $forcedownload whether the user must be forced to download the file.
+     * @return bool true if the user can access this file.
+     */
+    public function check_file_access($qa, $options, $component, $filearea, $args, $forcedownload) {
+        if ($component == 'question' && $filearea == 'response_files') {
+            // Response files are always visible.
+            // Assuming that the plugin that displays our question already checked if the user
+            // is allowed to see the question attempt.
+            return true;
+        }
+
+        // Parent method is not called, because we do not use questiontext and generalfeedback.
+        return false;
+    }
+
+    /**
      * Get the QuestionPy bridge used to retrieve additional information about an attempt.
      *
      * @throws moodle_exception


### PR DESCRIPTION
Ich habe noch zwei kleinere Probleme entdeckt:
1. Es fehlt ein require für die Konstante, da im Quiz die formslib.php noch nicht geladen wird.
2. Die von Usern hochgeladenen Dateien in der Abgabe konnte noch nicht heruntergeladen werden. Das assignsubmission_qpy Plugin muss auch noch angepasst werden. So sollte der Download aber schon mal in der Vorschau und im Quiz funktionieren.