### PR TITLE
feat: implement `summarise_response`

### DIFF
--- a/lang/en/qtype_questionpy.php
+++ b/lang/en/qtype_questionpy.php
@@ -78,6 +78,9 @@ $string['render_warnings_hint_contact_teachers'] = 'If you believe this to be in
 $string['request_error'] = 'The {$a->requestmethod} request to "{$a->uri}" failed with the error code "{$a->errorcode}" and'
     . ' status code {$a->statuscode} ({$a->reasonphrase}).';
 $string['response'] = 'Response';
+$string['response_summary_dynamic_data'] = 'Dynamic Data';
+$string['response_summary_files'] = 'Files';
+$string['response_summary_form_data'] = 'Form Data';
 $string['same_version_different_hash_error'] = 'A package with the same version but different hash already exists.';
 $string['scoring_state'] = 'QuestionPy Scoring State';
 $string['search_all_header'] = 'All ({$a})';

--- a/question.php
+++ b/question.php
@@ -335,6 +335,7 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
      *
      * @param array $response a response, as might be passed to {@see grade_response()}.
      * @return string a plain text summary of that response, that could be used in reports.
+     * @throws moodle_exception
      */
     public function summarise_response(array $response) {
         $summary = '';
@@ -349,7 +350,7 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
             if ($qpyresponse) {
                 ksort($qpyresponse);
 
-                $summary = 'Form Data:';
+                $summary .= get_string('response_summary_form_data', 'qtype_questionpy') . ':';
                 foreach ($qpyresponse as $key => $value) {
                     if ($key === 'data') {
                         continue;
@@ -359,7 +360,7 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
             }
 
             if ($dynamicdata) {
-                $summary .= 'Dynamic Data:';
+                $summary .= get_string('response_summary_dynamic_data', 'qtype_questionpy') . ':';
                 foreach ($dynamicdata as $key => $value) {
                     $summary .= $key . ': ' . json_encode($value) . ';';
                 }
@@ -368,9 +369,9 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
 
         $fileloader = $response[constants::QT_VAR_RESPONSE_FILES] ?? null;
         if ($fileloader) {
-            $summary .= 'Files:';
+            $summary .= get_string('response_summary_files', 'qtype_questionpy') . ':';
             foreach ($fileloader->get_files() as $file) {
-                $summary .= $file->get_filename() . ';';
+                $summary .= $file->get_filename() . ' (' . display_size($file->get_filesize()) . ');';
             }
         }
 

--- a/question.php
+++ b/question.php
@@ -348,13 +348,10 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
             unset($qpyresponse['data']);
 
             if ($qpyresponse) {
-                ksort($qpyresponse);
-
                 $summary .= get_string('response_summary_form_data', 'qtype_questionpy') . ':';
+
+                ksort($qpyresponse);
                 foreach ($qpyresponse as $key => $value) {
-                    if ($key === 'data') {
-                        continue;
-                    }
                     $summary .= $key . ': ' . $value . ';';
                 }
             }

--- a/question.php
+++ b/question.php
@@ -337,7 +337,44 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
      * @return string a plain text summary of that response, that could be used in reports.
      */
     public function summarise_response(array $response) {
-        return '';
+        $summary = '';
+
+        $qpyresponse = utils::get_qpy_response($response);
+
+        if ($qpyresponse) {
+            $qpyresponse = get_object_vars($qpyresponse);
+            $dynamicdata = get_object_vars($qpyresponse['data'] ?? (object) []);
+            unset($qpyresponse['data']);
+
+            if ($qpyresponse) {
+                ksort($qpyresponse);
+
+                $summary = 'Form Data:';
+                foreach ($qpyresponse as $key => $value) {
+                    if ($key === 'data') {
+                        continue;
+                    }
+                    $summary .= $key . ': ' . $value . ';';
+                }
+            }
+
+            if ($dynamicdata) {
+                $summary .= 'Dynamic Data:';
+                foreach ($dynamicdata as $key => $value) {
+                    $summary .= $key . ': ' . json_encode($value) . ';';
+                }
+            }
+        }
+
+        $fileloader = $response[constants::QT_VAR_RESPONSE_FILES] ?? null;
+        if ($fileloader) {
+            $summary .= 'Files:';
+            foreach ($fileloader->get_files() as $file) {
+                $summary .= $file->get_filename() . ';';
+            }
+        }
+
+        return $summary ?: '-';
     }
 
     /**


### PR DESCRIPTION
`get_right_answer_summary` funktioniert damit auch, da sie intern die `summarise_response`-Methode aufruft.

Abgabe mit Datein:
<img width="468" height="320" alt="image" src="https://github.com/user-attachments/assets/7456952d-e194-44c3-8dd3-f21345f39fab" />
(_`Saved: Files:upload!x.txt (2 bytes);`_)

Abgaben mit statischen und dynamischen Feldern:
<img width="468" height="486" alt="image" src="https://github.com/user-attachments/assets/4b4b976b-b4fc-4ed5-82d6-4f79d1d29a4c" />
(_`Saved: Form Data:result-0: 1;result-1: 0;result-2: 1;result-3: 0;Dynamic Data:intermediate-formula-order: [0];intermediate-formulas: {"0":"x <-> y"};intermediate-results: {"0":["0","1","0","1"]};intermediate-formula-counter: 1;`_)

**Anmerkung:**
Auf den Screenshots ist `Attempt finished submitting: -` zu sehen. `summarise_response` wird hier nämlich (fälschlicherweise (?)) nicht mit der richtigen Response aufgerufen (siehe unten rechts);
<img width="757" height="157" alt="image" src="https://github.com/user-attachments/assets/6d5281f7-138c-4392-8e00-78b30b7bf3e3" />
