### PR TITLE
feat: store error representation in qt-variable

### DIFF
--- a/classes/constants.php
+++ b/classes/constants.php
@@ -36,6 +36,8 @@ class constants {
     public const QT_VAR_SCORING_STATE = '_scoringstate';
     /** @var string */
     public const QT_VAR_RESPONSE = 'qpy_response';
+    /** @var string */
+    public const QT_VAR_ERROR = '_qpy_error';
 
     /** @var string This isn't needed after the action has been processed, so it's not a qt var. */
     public const FORM_DRAFT_AREAS = 'qpy_draft_areas';

--- a/question.php
+++ b/question.php
@@ -23,6 +23,7 @@
  */
 
 use qtype_questionpy\constants;
+use qtype_questionpy\exception\request_error;
 use qtype_questionpy\local\api\api;
 use qtype_questionpy\local\api\attempt;
 use qtype_questionpy\local\api\attempt_ui;
@@ -372,7 +373,7 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
             }
         }
 
-        return $summary ?: '-';
+        return $summary;
     }
 
     /**
@@ -426,6 +427,10 @@ class qtype_questionpy_question extends question_graded_automatically_with_count
             $event = \qtype_questionpy\event\grading_response_failed::create($params);
             $event->trigger();
             debugging($event->get_description(), backtrace: $t->getTrace());
+
+            // Our question behaviour constructs an error message containing this error representation.
+            $error = $t instanceof request_error ? $t->requesterrorcode->value : $t::class . "({$t->getCode()})";
+            $this->get_behaviour()->get_pending_step()->set_qt_var(constants::QT_VAR_ERROR, $error);
 
             // As the server was not able to score the response, we mark this question with manual scoring.
             return [0, question_state::$needsgrading];

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qtype_questionpy';
-$plugin->version = 2025100600;
+$plugin->version = 2025102300;
 $plugin->requires = 2024100700;
 $plugin->maturity = MATURITY_ALPHA;
 $plugin->release = '0.1';


### PR DESCRIPTION
Speichert einen Fehlercode in einer QT-Variable, welche von unserem Question-Behaviour (https://github.com/questionpy-org/moodle-qbehaviour_questionpy/pull/6) gelesen wird.